### PR TITLE
Allow vector-0.13

### DIFF
--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -34,7 +34,7 @@ Library
                      containers >= 0.5.7.0 && < 0.7,
                      text >= 0.11 && < 1.3 || >= 2.0 && < 2.1,
                      primes == 0.2.*,
-                     vector >= 0.12 && < 0.13,
+                     vector >= 0.12 && < 0.14,
                      commutative-semigroups >= 0.1 && < 0.2
   GHC-options:       -Wall
   default-language:  Haskell2010
@@ -43,7 +43,7 @@ test-suite Main
   Type:              exitcode-stdio-1.0
   Build-Depends:     base >= 4.9 && < 5,
                      bytestring >= 0.9 && < 1.0, containers >= 0.5.7.0 && < 0.7, text >= 0.11 && < 1.3 || >= 2.0 && < 2.1,
-                     vector >= 0.12 && < 0.13, primes == 0.2.*,
+                     vector >= 0.12 && < 0.14, primes == 0.2.*,
                      QuickCheck >= 2.9 && < 3, quickcheck-instances >= 0.3.12 && <0.4,
                      tasty >= 0.7, tasty-quickcheck >= 0.7 && < 1.0,
                      monoid-subclasses


### PR DESCRIPTION
As a Hackage trustee, I made a matching revision: https://hackage.haskell.org/package/monoid-subclasses-1.1.3/revisions/