### PR TITLE
Fix `Monus` instance for `Maybe`.

### DIFF
--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -290,7 +290,9 @@ overlappingGCDMonoidInstances = map upcast monusInstances
 monusInstances = [MonusInstance (mempty :: Product Natural),
                   MonusInstance (mempty :: Sum Natural),
                   MonusInstance (mempty :: Dual (Product Natural)),
+                  MonusInstance (mempty :: Maybe ()),
                   MonusInstance (mempty :: Maybe (Product Natural)),
+                  MonusInstance (mempty :: Maybe (Sum Natural)),
                   MonusInstance (mempty :: IntSet),
                   MonusInstance (mempty :: Set String)]
 

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -187,7 +187,11 @@ instance (OverlappingGCDMonoid a, OverlappingGCDMonoid b, OverlappingGCDMonoid c
 -- Maybe instances
 
 instance (Monus a, MonoidNull a) => Monus (Maybe a) where
-   Just a <\> Just b = Just (a <\> b)
+   Just a <\> Just b
+      | null remainder = Nothing
+      | otherwise = Just remainder
+    where
+      remainder = a <\> b
    Nothing <\> _ = Nothing
    x <\> Nothing = x
 


### PR DESCRIPTION
Hi @blamario 

I believe this fixes issue #38:

```patch
  instance (Monus a, MonoidNull a) => Monus (Maybe a) where
-    Just a <\> Just b = Just (a <\> b)
+    Just a <\> Just b
+       | null remainder = Nothing
+       | otherwise = Just remainder
+     where
+       remainder = a <\> b
     Nothing <\> _ = Nothing
     x <\> Nothing = x
```

With this change, the instance should now satisfy the following law:
```hs
a <\> a == mempty
```

I couldn't find an explicit statement of the above law in the [documentation for `Monus`](https://hackage.haskell.org/package/monoid-subclasses-1.2/docs/Data-Monoid-Monus.html#t:Monus), but this does seem to be one of the axioms for commutative monoids with monus. (I'm guessing it's currently implied by other laws.)

Does this also seem reasonable to you?

I've also added `MonusInstance` values for `Maybe ()` and `Maybe (Sum Natural)` to the test suite.

Let me know if you'd like me to adjust or add anything!

Jonathan