### PR TITLE
Fix haddock links to `GCDMonoid.gcd`.

### DIFF
--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -14,12 +14,12 @@ module Data.Monoid.LCM (
     )
 where
 
-import Prelude hiding (lcm, max)
+import Prelude hiding (gcd, lcm, max)
 import qualified Prelude
 
 import Data.IntSet (IntSet)
 import Data.Monoid (Dual (..), Product (..), Sum (..))
-import Data.Monoid.GCD (GCDMonoid)
+import Data.Monoid.GCD (GCDMonoid (..))
 import Data.Set (Set)
 import Numeric.Natural (Natural)
 import qualified Data.IntSet as IntSet


### PR DESCRIPTION
This PR fixes the documentation for `LCMMonoid` so that laws relating to `gcd` refer to `GCDMonoid.gcd` instead of `Prelude.gcd`.

<details><summary>Before</summary>

![Before](https://user-images.githubusercontent.com/206319/222991853-8ebc23d9-bd3c-48fc-a769-567885e72014.png)
</details>

<details><summary>After</summary>

![After](https://user-images.githubusercontent.com/206319/222991862-3653217c-dea9-4efa-9fc6-4a316756d89f.png)
Peek a boo!</details>