### PR TITLE
Distributive GCD and LCM monoids.

### DIFF
--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -626,15 +626,18 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("gcd idempotence", GCDTest checkGCD_idempotence),
          ("gcd identity (left)", GCDTest checkGCD_identity_left),
          ("gcd identity (right)", GCDTest checkGCD_identity_right),
+         ("gcd commutativity", GCDTest checkGCD_commutativity),
          ("gcd distributivity (left)", DistributiveGCDTest checkGCD_distributivity_left),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
          ("commonPrefix idempotence", LeftGCDTest checkCommonPrefix_idempotence),
          ("commonPrefix identity (left)", LeftGCDTest checkCommonPrefix_identity_left),
          ("commonPrefix identity (right)", LeftGCDTest checkCommonPrefix_identity_right),
+         ("commonPrefix commutativity", LeftGCDTest checkCommonPrefix_commutativity),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
          ("commonSuffix idempotence", RightGCDTest checkCommonSuffix_idempotence),
          ("commonSuffix identity (left)", RightGCDTest checkCommonSuffix_identity_left),
          ("commonSuffix identity (right)", RightGCDTest checkCommonSuffix_identity_right),
+         ("commonSuffix commutativity", RightGCDTest checkCommonSuffix_commutativity),
          ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
@@ -1079,6 +1082,11 @@ checkGCD_identity_right
         forAll (arbitrary :: Gen a) $
         \a -> gcd a mempty === mempty
 
+checkGCD_commutativity
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a)) $
+        \a b -> gcd a b === gcd b a
+
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1104,6 +1112,11 @@ checkCommonPrefix_identity_right
         forAll (arbitrary :: Gen a) $
         \a -> commonPrefix a mempty === mempty
 
+checkCommonPrefix_commutativity
+    (LeftGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a)) $
+        \a b -> commonPrefix a b === commonPrefix b a
+
 checkCommonPrefix_distributivity
     (LeftDistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1123,6 +1136,11 @@ checkCommonSuffix_identity_right
     (RightGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen a) $
         \a -> commonSuffix a mempty === mempty
+
+checkCommonSuffix_commutativity
+    (RightGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a)) $
+        \a b -> commonSuffix a b === commonSuffix b a
 
 checkCommonSuffix_distributivity
     (RightDistributiveGCDMonoidInstance (_ :: a)) =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -114,7 +114,6 @@ data Test = CommutativeTest (CommutativeMonoidInstance -> Property)
           | DistributiveGCDTest (DistributiveGCDMonoidInstance -> Property)
           | LeftDistributiveGCDTest (LeftDistributiveGCDMonoidInstance -> Property)
           | RightDistributiveGCDTest (RightDistributiveGCDMonoidInstance -> Property)
-          | CancellativeGCDTest (CancellativeGCDMonoidInstance -> Property)
           | LCMTest (LCMMonoidInstance -> Property)
           | DistributiveLCMTest (DistributiveLCMMonoidInstance -> Property)
 
@@ -157,8 +156,6 @@ data RightGCDMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, RightGCDMono
                               RightGCDMonoidInstance a
 data GCDMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, GCDMonoid a) =>
                          GCDMonoidInstance a
-data CancellativeGCDMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, Monoid a, Cancellative a, GCDMonoid a) =>
-                                     CancellativeGCDMonoidInstance a
 
 data DistributiveGCDMonoidInstance =
     forall a. (Arbitrary a, Show a, Eq a, DistributiveGCDMonoid a)
@@ -533,7 +530,6 @@ checkInstances (GCDTest checkType) = (map checkType gcdInstances)
 checkInstances (DistributiveGCDTest checkType) = (map checkType distributiveGCDMonoidInstances)
 checkInstances (LeftDistributiveGCDTest checkType) = (map checkType leftDistributiveGCDMonoidInstances)
 checkInstances (RightDistributiveGCDTest checkType) = (map checkType rightDistributiveGCDMonoidInstances)
-checkInstances (CancellativeGCDTest checkType) = (map checkType [CancellativeGCDMonoidInstance ()])
 checkInstances (LCMTest checkType) = (map checkType lcmInstances)
 checkInstances (DistributiveLCMTest checkType) = (map checkType distributiveLCMInstances)
 
@@ -627,7 +623,6 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
          ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
-         ("cancellative gcd", CancellativeGCDTest checkCancellativeGCD),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
          ("lcm uniqueness", LCMTest checkLCM_uniqueness),
@@ -1040,12 +1035,6 @@ checkGCD (GCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a)) check
                         && isJust (a </> d)
                         && isJust (b </> d)
             where d = gcd a b
-
-checkCancellativeGCD (CancellativeGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a, a)) check
-   where check (a, b, c) = commonPrefix (a <> b) (a <> c) == a <> (commonPrefix b c)
-                           && commonSuffix (a <> c) (b <> c) == (commonSuffix a b) <> c
-                           && gcd (a <> b) (a <> c) == a <> gcd b c
-                           && gcd (a <> c) (b <> c) == gcd a b <> c
 
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -360,9 +360,7 @@ rightCancellativeInstances = map upcast cancellativeInstances
                                 RightCancellativeMonoidInstance (mempty :: Vector Int)]
    where upcast (CancellativeMonoidInstance i) = RightCancellativeMonoidInstance i
 
-cancellativeInstances = map upcast [CancellativeGCDMonoidInstance ()]
-                        ++ []
-   where upcast (CancellativeGCDMonoidInstance i) = CancellativeMonoidInstance i
+cancellativeInstances = [CancellativeMonoidInstance ()]
 
 leftGCDInstances = map upcast gcdInstances
                    ++ [LeftGCDMonoidInstance (mempty :: String),

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -603,6 +603,7 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("overlap law 1", OverlappingGCDTest checkOverlapLaw1),
          ("overlap law 2", OverlappingGCDTest checkOverlapLaw2),
          ("overlap law 3", OverlappingGCDTest checkOverlapLaw3),
+         ("overlap idempotence", OverlappingGCDTest checkOverlap_idempotence),
          ("isPrefixOf", LeftReductiveTest checkIsPrefixOf),
          ("stripSuffix", RightReductiveTest checkStripSuffix),
          ("isSuffixOf", RightReductiveTest checkIsSuffixOf),
@@ -620,9 +621,12 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("stripCommonSuffix 4", RightGCDTest checkStripCommonSuffix4),
          ("gcd", GCDTest checkGCD),
          ("gcd uniqueness", GCDTest checkGCD_uniqueness),
+         ("gcd idempotence", GCDTest checkGCD_idempotence),
          ("gcd distributivity (left)", DistributiveGCDTest checkGCD_distributivity_left),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
+         ("commonPrefix idempotence", LeftGCDTest checkCommonPrefix_idempotence),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
+         ("commonSuffix idempotence", RightGCDTest checkCommonSuffix_idempotence),
          ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
@@ -952,6 +956,9 @@ checkOverlapLaw2 (OverlappingGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: 
 checkOverlapLaw3 (OverlappingGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a)) check
    where check (a, b) = overlap a b <> stripPrefixOverlap a b == b
 
+checkOverlap_idempotence (OverlappingGCDMonoidInstance (_ :: a)) =
+    forAll (arbitrary :: Gen a) $ \a -> overlap a a === a
+
 checkStripPrefixOverlap1 (OverlappingGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a)) check
    where check (a, b) = o `isSuffixOf` b && b `isSuffixOf` (a <> o)
             where o = stripPrefixOverlap a b
@@ -1043,6 +1050,11 @@ checkGCD_uniqueness
         \(a, b, c) ->
             all isJust [a </> c, b </> c, c </> gcd a b] === (gcd a b == c)
 
+checkGCD_idempotence
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> gcd a a === a
+
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1053,10 +1065,20 @@ checkGCD_distributivity_right
         forAll (arbitrary :: Gen (a, a, a)) $
         \(a, b, c) -> gcd (a <> c) (b <> c) == gcd a b <> c
 
+checkCommonPrefix_idempotence
+    (LeftGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonPrefix a a === a
+
 checkCommonPrefix_distributivity
     (LeftDistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
         \(a, b, c) -> commonPrefix (a <> b) (a <> c) == a <> commonPrefix b c
+
+checkCommonSuffix_idempotence
+    (RightGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonSuffix a a === a
 
 checkCommonSuffix_distributivity
     (RightDistributiveGCDMonoidInstance (_ :: a)) =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -604,6 +604,8 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("overlap law 2", OverlappingGCDTest checkOverlapLaw2),
          ("overlap law 3", OverlappingGCDTest checkOverlapLaw3),
          ("overlap idempotence", OverlappingGCDTest checkOverlap_idempotence),
+         ("overlap identity (left)", OverlappingGCDTest checkOverlap_identity_left),
+         ("overlap identity (right)", OverlappingGCDTest checkOverlap_identity_right),
          ("isPrefixOf", LeftReductiveTest checkIsPrefixOf),
          ("stripSuffix", RightReductiveTest checkStripSuffix),
          ("isSuffixOf", RightReductiveTest checkIsSuffixOf),
@@ -622,11 +624,17 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("gcd", GCDTest checkGCD),
          ("gcd uniqueness", GCDTest checkGCD_uniqueness),
          ("gcd idempotence", GCDTest checkGCD_idempotence),
+         ("gcd identity (left)", GCDTest checkGCD_identity_left),
+         ("gcd identity (right)", GCDTest checkGCD_identity_right),
          ("gcd distributivity (left)", DistributiveGCDTest checkGCD_distributivity_left),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
          ("commonPrefix idempotence", LeftGCDTest checkCommonPrefix_idempotence),
+         ("commonPrefix identity (left)", LeftGCDTest checkCommonPrefix_identity_left),
+         ("commonPrefix identity (right)", LeftGCDTest checkCommonPrefix_identity_right),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
          ("commonSuffix idempotence", RightGCDTest checkCommonSuffix_idempotence),
+         ("commonSuffix identity (left)", RightGCDTest checkCommonSuffix_identity_left),
+         ("commonSuffix identity (right)", RightGCDTest checkCommonSuffix_identity_right),
          ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
@@ -959,6 +967,12 @@ checkOverlapLaw3 (OverlappingGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: 
 checkOverlap_idempotence (OverlappingGCDMonoidInstance (_ :: a)) =
     forAll (arbitrary :: Gen a) $ \a -> overlap a a === a
 
+checkOverlap_identity_left (OverlappingGCDMonoidInstance (_ :: a)) =
+    forAll (arbitrary :: Gen a) $ \a -> overlap mempty a === mempty
+
+checkOverlap_identity_right (OverlappingGCDMonoidInstance (_ :: a)) =
+    forAll (arbitrary :: Gen a) $ \a -> overlap a mempty === mempty
+
 checkStripPrefixOverlap1 (OverlappingGCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a)) check
    where check (a, b) = o `isSuffixOf` b && b `isSuffixOf` (a <> o)
             where o = stripPrefixOverlap a b
@@ -1055,6 +1069,16 @@ checkGCD_idempotence
         forAll (arbitrary :: Gen a) $
         \a -> gcd a a === a
 
+checkGCD_identity_left
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> gcd mempty a === mempty
+
+checkGCD_identity_right
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> gcd a mempty === mempty
+
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1070,6 +1094,16 @@ checkCommonPrefix_idempotence
         forAll (arbitrary :: Gen a) $
         \a -> commonPrefix a a === a
 
+checkCommonPrefix_identity_left
+    (LeftGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonPrefix mempty a === mempty
+
+checkCommonPrefix_identity_right
+    (LeftGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonPrefix a mempty === mempty
+
 checkCommonPrefix_distributivity
     (LeftDistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1079,6 +1113,16 @@ checkCommonSuffix_idempotence
     (RightGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen a) $
         \a -> commonSuffix a a === a
+
+checkCommonSuffix_identity_left
+    (RightGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonSuffix mempty a === mempty
+
+checkCommonSuffix_identity_right
+    (RightGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen a) $
+        \a -> commonSuffix a mempty === mempty
 
 checkCommonSuffix_distributivity
     (RightDistributiveGCDMonoidInstance (_ :: a)) =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -619,6 +619,7 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("stripCommonSuffix 3", RightGCDTest checkStripCommonSuffix3),
          ("stripCommonSuffix 4", RightGCDTest checkStripCommonSuffix4),
          ("gcd", GCDTest checkGCD),
+         ("gcd uniqueness", GCDTest checkGCD_uniqueness),
          ("gcd distributivity (left)", DistributiveGCDTest checkGCD_distributivity_left),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
@@ -1035,6 +1036,12 @@ checkGCD (GCDMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen (a, a)) check
                         && isJust (a </> d)
                         && isJust (b </> d)
             where d = gcd a b
+
+checkGCD_uniqueness
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \(a, b, c) ->
+            all isJust [a </> c, b </> c, c </> gcd a b] === (gcd a b == c)
 
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -71,9 +71,16 @@ import Data.Semigroup.Cancellative (Commutative, Reductive,
 import Data.Monoid.Null (MonoidNull, PositiveMonoid, null)
 import Data.Monoid.Factorial (FactorialMonoid,
                               splitPrimePrefix, splitPrimeSuffix, inits, tails, span, spanMaybe, split, splitAt)
-import Data.Monoid.GCD (GCDMonoid, LeftGCDMonoid, RightGCDMonoid, gcd,
-                        commonPrefix, stripCommonPrefix,
-                        commonSuffix, stripCommonSuffix)
+import Data.Monoid.GCD
+    ( GCDMonoid
+    , LeftGCDMonoid
+    , RightGCDMonoid
+    , commonPrefix
+    , commonSuffix
+    , gcd
+    , stripCommonPrefix
+    , stripCommonSuffix
+    )
 import Data.Monoid.LCM (LCMMonoid, lcm)
 import Data.Monoid.Monus (OverlappingGCDMonoid, Monus,
                           (<\>), overlap, stripOverlap, stripPrefixOverlap, stripSuffixOverlap)

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -360,7 +360,7 @@ rightCancellativeInstances = map upcast cancellativeInstances
                                 RightCancellativeMonoidInstance (mempty :: Vector Int)]
    where upcast (CancellativeMonoidInstance i) = RightCancellativeMonoidInstance i
 
-cancellativeInstances = map upcast cancellativeGCDInstances
+cancellativeInstances = map upcast [CancellativeGCDMonoidInstance ()]
                         ++ []
    where upcast (CancellativeGCDMonoidInstance i) = CancellativeMonoidInstance i
 
@@ -401,14 +401,12 @@ rightGCDInstances = map upcast gcdInstances
                        RightGCDMonoidInstance (mempty :: Concat (Dual Text))]
    where upcast (GCDMonoidInstance i) = RightGCDMonoidInstance i
 
-gcdInstances = map upcast cancellativeGCDInstances
+gcdInstances = map upcast [CancellativeGCDMonoidInstance ()]
                ++ [GCDMonoidInstance (mempty :: Product Natural),
                    GCDMonoidInstance (mempty :: Dual (Product Natural)),
                    GCDMonoidInstance (mempty :: IntSet),
                    GCDMonoidInstance (mempty :: Set String)]
    where upcast (CancellativeGCDMonoidInstance i) = GCDMonoidInstance i
-
-cancellativeGCDInstances = [CancellativeGCDMonoidInstance ()]
 
 distributiveGCDMonoidInstances :: [DistributiveGCDMonoidInstance]
 distributiveGCDMonoidInstances =
@@ -536,7 +534,7 @@ checkInstances (GCDTest checkType) = (map checkType gcdInstances)
 checkInstances (DistributiveGCDTest checkType) = (map checkType distributiveGCDMonoidInstances)
 checkInstances (LeftDistributiveGCDTest checkType) = (map checkType leftDistributiveGCDMonoidInstances)
 checkInstances (RightDistributiveGCDTest checkType) = (map checkType rightDistributiveGCDMonoidInstances)
-checkInstances (CancellativeGCDTest checkType) = (map checkType cancellativeGCDInstances) 
+checkInstances (CancellativeGCDTest checkType) = (map checkType [CancellativeGCDMonoidInstance ()])
 checkInstances (LCMTest checkType) = (map checkType lcmInstances)
 checkInstances (DistributiveLCMTest checkType) = (map checkType distributiveLCMInstances)
 

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -75,6 +75,8 @@ import Data.Monoid.GCD
     ( GCDMonoid
     , LeftGCDMonoid
     , RightGCDMonoid
+    , LeftDistributiveGCDMonoid
+    , RightDistributiveGCDMonoid
     , commonPrefix
     , commonSuffix
     , gcd
@@ -104,6 +106,8 @@ data Test = CommutativeTest (CommutativeMonoidInstance -> Property)
           | LeftGCDTest (LeftGCDMonoidInstance -> Property)
           | RightGCDTest (RightGCDMonoidInstance -> Property)
           | GCDTest (GCDMonoidInstance -> Property)
+          | LeftDistributiveGCDTest (LeftDistributiveGCDMonoidInstance -> Property)
+          | RightDistributiveGCDTest (RightDistributiveGCDMonoidInstance -> Property)
           | CancellativeGCDTest (CancellativeGCDMonoidInstance -> Property)
           | LCMTest (LCMMonoidInstance -> Property)
 
@@ -148,6 +152,15 @@ data GCDMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, GCDMonoid a) =>
                          GCDMonoidInstance a
 data CancellativeGCDMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, Monoid a, Cancellative a, GCDMonoid a) =>
                                      CancellativeGCDMonoidInstance a
+
+data LeftDistributiveGCDMonoidInstance =
+    forall a. (Arbitrary a, Show a, Eq a, LeftDistributiveGCDMonoid a)
+        => LeftDistributiveGCDMonoidInstance a
+
+data RightDistributiveGCDMonoidInstance =
+    forall a. (Arbitrary a, Show a, Eq a, RightDistributiveGCDMonoid a)
+        => RightDistributiveGCDMonoidInstance a
+
 data LCMMonoidInstance = forall a. (Arbitrary a, Show a, Eq a, LCMMonoid a) =>
                          LCMMonoidInstance a
 
@@ -381,6 +394,66 @@ gcdInstances = map upcast cancellativeGCDInstances
 
 cancellativeGCDInstances = [CancellativeGCDMonoidInstance ()]
 
+leftDistributiveGCDMonoidInstances :: [LeftDistributiveGCDMonoidInstance]
+leftDistributiveGCDMonoidInstances =
+    [ -- Instances for non-commutative monoids:
+      LeftDistributiveGCDMonoidInstance (mempty :: [()])
+    , LeftDistributiveGCDMonoidInstance (mempty :: [Bool])
+    , LeftDistributiveGCDMonoidInstance (mempty :: [Word])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Seq ())
+    , LeftDistributiveGCDMonoidInstance (mempty :: Seq Bool)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Seq Word)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Vector ())
+    , LeftDistributiveGCDMonoidInstance (mempty :: Vector Bool)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Vector Word)
+    , LeftDistributiveGCDMonoidInstance (mempty :: ByteString)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Lazy.ByteString)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Text)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Lazy.Text)
+      -- Instances for commutative monoids:
+    , LeftDistributiveGCDMonoidInstance (mempty :: ())
+    , LeftDistributiveGCDMonoidInstance (mempty :: Product Natural)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Sum Natural)
+    , LeftDistributiveGCDMonoidInstance (mempty :: IntSet)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Set ())
+    , LeftDistributiveGCDMonoidInstance (mempty :: Set Bool)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Set Word)
+      -- Instances for monoid transformers:
+    , LeftDistributiveGCDMonoidInstance (mempty :: Dual [()])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Word])
+    ]
+
+rightDistributiveGCDMonoidInstances :: [RightDistributiveGCDMonoidInstance]
+rightDistributiveGCDMonoidInstances =
+    [ -- Instances for non-commutative monoids:
+      RightDistributiveGCDMonoidInstance (mempty :: [()])
+    , RightDistributiveGCDMonoidInstance (mempty :: [Bool])
+    , RightDistributiveGCDMonoidInstance (mempty :: [Word])
+    , RightDistributiveGCDMonoidInstance (mempty :: Seq ())
+    , RightDistributiveGCDMonoidInstance (mempty :: Seq Bool)
+    , RightDistributiveGCDMonoidInstance (mempty :: Seq Word)
+    , RightDistributiveGCDMonoidInstance (mempty :: Vector ())
+    , RightDistributiveGCDMonoidInstance (mempty :: Vector Bool)
+    , RightDistributiveGCDMonoidInstance (mempty :: Vector Word)
+    , RightDistributiveGCDMonoidInstance (mempty :: ByteString)
+    , RightDistributiveGCDMonoidInstance (mempty :: Lazy.ByteString)
+    , RightDistributiveGCDMonoidInstance (mempty :: Text)
+    , RightDistributiveGCDMonoidInstance (mempty :: Lazy.Text)
+      -- Instances for commutative monoids:
+    , RightDistributiveGCDMonoidInstance (mempty :: ())
+    , RightDistributiveGCDMonoidInstance (mempty :: Product Natural)
+    , RightDistributiveGCDMonoidInstance (mempty :: Sum Natural)
+    , RightDistributiveGCDMonoidInstance (mempty :: IntSet)
+    , RightDistributiveGCDMonoidInstance (mempty :: Set ())
+    , RightDistributiveGCDMonoidInstance (mempty :: Set Bool)
+    , RightDistributiveGCDMonoidInstance (mempty :: Set Word)
+      -- Instances for monoid transformers:
+    , RightDistributiveGCDMonoidInstance (mempty :: Dual [()])
+    , RightDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
+    , RightDistributiveGCDMonoidInstance (mempty :: Dual [Word])
+    ]
+
 lcmInstances =
     [LCMMonoidInstance (mempty :: Product Natural),
      LCMMonoidInstance (mempty :: Sum Natural),
@@ -418,6 +491,8 @@ checkInstances (MonusTest checkType) = (map checkType monusInstances)
 checkInstances (LeftGCDTest checkType) = (map checkType leftGCDInstances) 
 checkInstances (RightGCDTest checkType) = (map checkType rightGCDInstances) 
 checkInstances (GCDTest checkType) = (map checkType gcdInstances)  
+checkInstances (LeftDistributiveGCDTest checkType) = (map checkType leftDistributiveGCDMonoidInstances)
+checkInstances (RightDistributiveGCDTest checkType) = (map checkType rightDistributiveGCDMonoidInstances)
 checkInstances (CancellativeGCDTest checkType) = (map checkType cancellativeGCDInstances) 
 checkInstances (LCMTest checkType) = (map checkType lcmInstances)
 
@@ -507,6 +582,8 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("stripCommonSuffix 3", RightGCDTest checkStripCommonSuffix3),
          ("stripCommonSuffix 4", RightGCDTest checkStripCommonSuffix4),
          ("gcd", GCDTest checkGCD),
+         ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
+         ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
          ("cancellative gcd", CancellativeGCDTest checkCancellativeGCD),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
@@ -926,6 +1003,16 @@ checkCancellativeGCD (CancellativeGCDMonoidInstance (_ :: a)) = forAll (arbitrar
                            && commonSuffix (a <> c) (b <> c) == (commonSuffix a b) <> c
                            && gcd (a <> b) (a <> c) == a <> gcd b c
                            && gcd (a <> c) (b <> c) == gcd a b <> c
+
+checkCommonPrefix_distributivity
+    (LeftDistributiveGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \(a, b, c) -> commonPrefix (a <> b) (a <> c) == a <> commonPrefix b c
+
+checkCommonSuffix_distributivity
+    (RightDistributiveGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \(a, b, c) -> commonSuffix (a <> c) (b <> c) == commonSuffix a b <> c
 
 checkLCM_reductivity_left (LCMMonoidInstance (_ :: a)) =
     forAll (arbitrary :: Gen (a, a)) check

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -401,12 +401,13 @@ rightGCDInstances = map upcast gcdInstances
                        RightGCDMonoidInstance (mempty :: Concat (Dual Text))]
    where upcast (GCDMonoidInstance i) = RightGCDMonoidInstance i
 
-gcdInstances = map upcast [CancellativeGCDMonoidInstance ()]
-               ++ [GCDMonoidInstance (mempty :: Product Natural),
-                   GCDMonoidInstance (mempty :: Dual (Product Natural)),
-                   GCDMonoidInstance (mempty :: IntSet),
-                   GCDMonoidInstance (mempty :: Set String)]
-   where upcast (CancellativeGCDMonoidInstance i) = GCDMonoidInstance i
+gcdInstances =
+    [ GCDMonoidInstance (mempty :: ())
+    , GCDMonoidInstance (mempty :: Product Natural)
+    , GCDMonoidInstance (mempty :: Dual (Product Natural))
+    , GCDMonoidInstance (mempty :: IntSet)
+    , GCDMonoidInstance (mempty :: Set String)
+    ]
 
 distributiveGCDMonoidInstances :: [DistributiveGCDMonoidInstance]
 distributiveGCDMonoidInstances =

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -627,17 +627,20 @@ tests = [("CommutativeMonoid", CommutativeTest checkCommutative),
          ("gcd identity (left)", GCDTest checkGCD_identity_left),
          ("gcd identity (right)", GCDTest checkGCD_identity_right),
          ("gcd commutativity", GCDTest checkGCD_commutativity),
+         ("gcd associativity", GCDTest checkGCD_associativity),
          ("gcd distributivity (left)", DistributiveGCDTest checkGCD_distributivity_left),
          ("gcd distributivity (right)", DistributiveGCDTest checkGCD_distributivity_right),
          ("commonPrefix idempotence", LeftGCDTest checkCommonPrefix_idempotence),
          ("commonPrefix identity (left)", LeftGCDTest checkCommonPrefix_identity_left),
          ("commonPrefix identity (right)", LeftGCDTest checkCommonPrefix_identity_right),
          ("commonPrefix commutativity", LeftGCDTest checkCommonPrefix_commutativity),
+         ("commonPrefix associativity", LeftGCDTest checkCommonPrefix_associativity),
          ("commonPrefix distributivity", LeftDistributiveGCDTest checkCommonPrefix_distributivity),
          ("commonSuffix idempotence", RightGCDTest checkCommonSuffix_idempotence),
          ("commonSuffix identity (left)", RightGCDTest checkCommonSuffix_identity_left),
          ("commonSuffix identity (right)", RightGCDTest checkCommonSuffix_identity_right),
          ("commonSuffix commutativity", RightGCDTest checkCommonSuffix_commutativity),
+         ("commonSuffix associativity", RightGCDTest checkCommonSuffix_associativity),
          ("commonSuffix distributivity", RightDistributiveGCDTest checkCommonSuffix_distributivity),
          ("lcm reductivity (left)", LCMTest checkLCM_reductivity_left),
          ("lcm reductivity (right)", LCMTest checkLCM_reductivity_right),
@@ -1087,6 +1090,11 @@ checkGCD_commutativity
         forAll (arbitrary :: Gen (a, a)) $
         \a b -> gcd a b === gcd b a
 
+checkGCD_associativity
+    (GCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \a b c -> gcd a (gcd b c) === gcd (gcd a b) c
+
 checkGCD_distributivity_left
     (DistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1117,6 +1125,13 @@ checkCommonPrefix_commutativity
         forAll (arbitrary :: Gen (a, a)) $
         \a b -> commonPrefix a b === commonPrefix b a
 
+checkCommonPrefix_associativity
+    (LeftGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \a b c ->
+            (commonPrefix a (commonPrefix b c)) ===
+            (commonPrefix (commonPrefix a b) c)
+
 checkCommonPrefix_distributivity
     (LeftDistributiveGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a, a)) $
@@ -1141,6 +1156,13 @@ checkCommonSuffix_commutativity
     (RightGCDMonoidInstance (_ :: a)) =
         forAll (arbitrary :: Gen (a, a)) $
         \a b -> commonSuffix a b === commonSuffix b a
+
+checkCommonSuffix_associativity
+    (RightGCDMonoidInstance (_ :: a)) =
+        forAll (arbitrary :: Gen (a, a, a)) $
+        \a b c ->
+            (commonSuffix a (commonSuffix b c)) ===
+            (commonSuffix (commonSuffix a b) c)
 
 checkCommonSuffix_distributivity
     (RightDistributiveGCDMonoidInstance (_ :: a)) =

--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -23,12 +23,22 @@ Source-repository head
 
 Library
   hs-source-dirs:    src
-  Exposed-Modules:   Data.Semigroup.Cancellative, Data.Semigroup.Factorial,
-                     Data.Monoid.Cancellative, Data.Monoid.GCD, Data.Monoid.LCM, Data.Monoid.Monus,
-                     Data.Monoid.Factorial, Data.Monoid.Null, Data.Monoid.Textual,
-                     Data.Monoid.Instances.ByteString.UTF8, Data.Monoid.Instances.CharVector,
-                     Data.Monoid.Instances.Concat, Data.Monoid.Instances.Measured, Data.Monoid.Instances.Positioned,
-                     Data.Monoid.Instances.Stateful
+  Exposed-Modules:
+                     Data.Monoid.Cancellative
+                   , Data.Monoid.Factorial
+                   , Data.Monoid.GCD
+                   , Data.Monoid.Instances.ByteString.UTF8
+                   , Data.Monoid.Instances.CharVector
+                   , Data.Monoid.Instances.Concat
+                   , Data.Monoid.Instances.Measured
+                   , Data.Monoid.Instances.Positioned
+                   , Data.Monoid.Instances.Stateful
+                   , Data.Monoid.LCM
+                   , Data.Monoid.Monus
+                   , Data.Monoid.Null
+                   , Data.Monoid.Textual
+                   , Data.Semigroup.Cancellative
+                   , Data.Semigroup.Factorial
   Build-Depends:     base >= 4.9 && < 5,
                      bytestring >= 0.9 && < 1.0,
                      containers >= 0.5.7.0 && < 0.7,

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -106,6 +106,12 @@ import Prelude hiding (gcd)
 -- 'gcd' a b '==' 'gcd' b a
 -- @
 --
+-- __/Associativity/__
+--
+-- @
+-- 'gcd' ('gcd' a b) c '==' 'gcd' a ('gcd' b c)
+-- @
+--
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m
 
@@ -150,6 +156,14 @@ class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, 
 --
 -- @
 -- 'commonPrefix' a b '==' 'commonPrefix' b a
+-- @
+--
+-- __/Associativity/__
+--
+-- @
+-- 'commonPrefix' ('commonPrefix' a b) c
+-- '=='
+-- 'commonPrefix' a ('commonPrefix' b c)
 -- @
 --
 class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
@@ -205,6 +219,14 @@ class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
 --
 -- @
 -- 'commonSuffix' a b '==' 'commonSuffix' b a
+-- @
+--
+-- __/Associativity/__
+--
+-- @
+-- 'commonSuffix' ('commonSuffix' a b) c
+-- '=='
+-- 'commonSuffix' a ('commonSuffix' b c)
 -- @
 --
 class (Monoid m, RightReductive m) => RightGCDMonoid m where

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -68,10 +68,6 @@ import Prelude hiding (gcd)
 -- > Just a' = a </> p && Just b' = b </> p
 -- >    where p = gcd a b
 --
--- If a 'GCDMonoid' happens to also be 'Cancellative', it should additionally satisfy the following laws:
---
--- > gcd (a <> b) (a <> c) == a <> gcd b c
--- > gcd (a <> c) (b <> c) == gcd a b <> c
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m
 

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -9,15 +9,45 @@
 -- The 'GCDMonoid' subclass adds the 'gcd' operation which takes two monoidal arguments and finds their greatest
 -- common divisor, or (more generally) the greatest monoid that can be extracted with the '</>' operation from both.
 --
--- The 'GCDMonoid' class is for Abelian, /i.e./, 'Commutative' monoids. Since most practical monoids in Haskell are not
--- Abelian, there are also its three symmetric superclasses:
--- 
+-- The 'GCDMonoid' class is for Abelian, /i.e./, 'Commutative' monoids.
+--
+-- == Non-commutative GCD monoids
+--
+--  Since most practical monoids in Haskell are not Abelian, the 'GCDMonoid'
+--  class has three symmetric superclasses:
+--
 -- * 'LeftGCDMonoid'
--- 
+--
+--      Class of monoids for which it is possible to find the greatest common
+--      /prefix/ of two monoidal values.
+--
 -- * 'RightGCDMonoid'
--- 
+--
+--      Class of monoids for which it is possible to find the greatest common
+--      /suffix/ of two monoidal values.
+--
 -- * 'OverlappingGCDMonoid'
-
+--
+--      Class of monoids for which it is possible to find the greatest common
+--      /overlap/ of two monoidal values.
+--
+-- == Distributive GCD monoids
+--
+-- Since some (but not all) GCD monoids are also distributive, there are three
+-- subclasses that add distributivity:
+--
+-- * 'DistributiveGCDMonoid'
+--
+--     Subclass of 'GCDMonoid' with /symmetric/ distributivity.
+--
+-- * 'LeftDistributiveGCDMonoid'
+--
+--     Subclass of 'LeftGCDMonoid' with /left/-distributivity.
+--
+-- * 'RightDistributiveGCDMonoid'
+--
+--     Subclass of 'RightGCDMonoid' with /right/-distributivity.
+--
 {-# LANGUAGE CPP, Haskell2010, FlexibleInstances, Trustworthy #-}
 
 module Data.Monoid.GCD

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -91,6 +91,15 @@ import Prelude hiding (gcd)
 -- 'gcd' a a '==' a
 -- @
 --
+-- __/Identity/__
+--
+-- @
+-- 'gcd' 'mempty' a '==' 'mempty'
+-- @
+-- @
+-- 'gcd' a 'mempty' '==' 'mempty'
+-- @
+--
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m
 
@@ -120,6 +129,15 @@ class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, 
 --
 -- @
 -- 'commonPrefix' a a '==' a
+-- @
+--
+-- __/Identity/__
+--
+-- @
+-- 'commonPrefix' 'mempty' a '==' 'mempty'
+-- @
+-- @
+-- 'commonPrefix' a 'mempty' '==' 'mempty'
 -- @
 --
 class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
@@ -160,6 +178,15 @@ class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
 --
 -- @
 -- 'commonSuffix' a a '==' a
+-- @
+--
+-- __/Identity/__
+--
+-- @
+-- 'commonSuffix' 'mempty' a '==' 'mempty'
+-- @
+-- @
+-- 'commonSuffix' a 'mempty' '==' 'mempty'
 -- @
 --
 class (Monoid m, RightReductive m) => RightGCDMonoid m where

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -20,11 +20,13 @@
 
 {-# LANGUAGE CPP, Haskell2010, FlexibleInstances, Trustworthy #-}
 
-module Data.Monoid.GCD (
-   GCDMonoid(..),
-   LeftGCDMonoid(..), RightGCDMonoid(..), OverlappingGCDMonoid(..)
-   )
-where
+module Data.Monoid.GCD
+    ( GCDMonoid (..)
+    , LeftGCDMonoid (..)
+    , RightGCDMonoid (..)
+    , OverlappingGCDMonoid (..)
+    )
+    where
 
 import qualified Prelude
 

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -25,6 +25,8 @@ module Data.Monoid.GCD
     , LeftGCDMonoid (..)
     , RightGCDMonoid (..)
     , OverlappingGCDMonoid (..)
+    , LeftDistributiveGCDMonoid
+    , RightDistributiveGCDMonoid
     )
     where
 
@@ -457,3 +459,71 @@ instance RightGCDMonoid LazyText.Text where
           stripCommonSuffix (LazyEncoding.encodeUtf8 x) (LazyEncoding.encodeUtf8 y)
     in (LazyEncoding.decodeUtf8 xlist, LazyEncoding.decodeUtf8 ylist, LazyEncoding.decodeUtf8 slist)
 #endif
+
+-------------------------------------------------------------------------------
+-- LeftDistributiveGCDMonoid
+--------------------------------------------------------------------------------
+
+-- | Class of /left/ GCD monoids with /left/-distributivity.
+--
+-- In addition to the general 'LeftGCDMonoid' laws, instances of this class
+-- must also satisfy the following law:
+--
+-- @
+-- 'commonPrefix' (a '<>' b) (a '<>' c) '==' a '<>' 'commonPrefix' b c
+-- @
+--
+class LeftGCDMonoid m => LeftDistributiveGCDMonoid m
+
+-- Instances for non-commutative monoids:
+instance Eq a => LeftDistributiveGCDMonoid [a]
+instance Eq a => LeftDistributiveGCDMonoid (Sequence.Seq a)
+instance Eq a => LeftDistributiveGCDMonoid (Vector.Vector a)
+instance LeftDistributiveGCDMonoid ByteString.ByteString
+instance LeftDistributiveGCDMonoid LazyByteString.ByteString
+instance LeftDistributiveGCDMonoid Text.Text
+instance LeftDistributiveGCDMonoid LazyText.Text
+
+-- Instances for commutative monoids:
+instance LeftDistributiveGCDMonoid ()
+instance LeftDistributiveGCDMonoid (Product Natural)
+instance LeftDistributiveGCDMonoid (Sum Natural)
+instance LeftDistributiveGCDMonoid IntSet.IntSet
+instance Ord a => LeftDistributiveGCDMonoid (Set.Set a)
+
+-- Instances for monoid transformers:
+instance RightDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Dual a)
+
+--------------------------------------------------------------------------------
+-- RightDistributiveGCDMonoid
+--------------------------------------------------------------------------------
+
+-- | Class of /right/ GCD monoids with /right/-distributivity.
+--
+-- In addition to the general 'RightGCDMonoid' laws, instances of this class
+-- must also satisfy the following law:
+--
+-- @
+-- 'commonSuffix' (a '<>' c) (b '<>' c) '==' 'commonSuffix' a b '<>' c
+-- @
+--
+class RightGCDMonoid m => RightDistributiveGCDMonoid m
+
+-- Instances for non-commutative monoids:
+instance Eq a => RightDistributiveGCDMonoid [a]
+instance Eq a => RightDistributiveGCDMonoid (Sequence.Seq a)
+instance Eq a => RightDistributiveGCDMonoid (Vector.Vector a)
+instance RightDistributiveGCDMonoid ByteString.ByteString
+instance RightDistributiveGCDMonoid LazyByteString.ByteString
+instance RightDistributiveGCDMonoid Text.Text
+instance RightDistributiveGCDMonoid LazyText.Text
+
+-- Instances for commutative monoids:
+instance RightDistributiveGCDMonoid ()
+instance RightDistributiveGCDMonoid (Product Natural)
+instance RightDistributiveGCDMonoid (Sum Natural)
+instance RightDistributiveGCDMonoid IntSet.IntSet
+instance Ord a => RightDistributiveGCDMonoid (Set.Set a)
+
+-- Instances for monoid transformers:
+instance LeftDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Dual a)

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -59,6 +59,9 @@ import Numeric.Natural (Natural)
 import Data.Semigroup.Cancellative
 import Data.Monoid.Monus
 
+-- These imports are marked as redundant, but are actually required by haddock:
+import Data.Maybe (isJust)
+
 import Prelude hiding (gcd)
 
 -- | Class of Abelian monoids that allow the greatest common divisor to be found for any two given values. The
@@ -67,6 +70,20 @@ import Prelude hiding (gcd)
 -- > gcd a b == commonPrefix a b == commonSuffix a b
 -- > Just a' = a </> p && Just b' = b </> p
 -- >    where p = gcd a b
+--
+-- In addition, the 'gcd' operation must satisfy the following properties:
+--
+-- __/Uniqueness/__
+--
+-- @
+-- 'all' 'isJust'
+--     [ a '</>' c
+--     , b '</>' c
+--     , c '</>' 'gcd' a b
+--     ]
+-- ==>
+--     (c '==' 'gcd' a b)
+-- @
 --
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -100,6 +100,12 @@ import Prelude hiding (gcd)
 -- 'gcd' a 'mempty' '==' 'mempty'
 -- @
 --
+-- __/Commutativity/__
+--
+-- @
+-- 'gcd' a b '==' 'gcd' b a
+-- @
+--
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m
 
@@ -138,6 +144,12 @@ class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, 
 -- @
 -- @
 -- 'commonPrefix' a 'mempty' '==' 'mempty'
+-- @
+--
+-- __/Commutativity/__
+--
+-- @
+-- 'commonPrefix' a b '==' 'commonPrefix' b a
 -- @
 --
 class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
@@ -187,6 +199,12 @@ class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
 -- @
 -- @
 -- 'commonSuffix' a 'mempty' '==' 'mempty'
+-- @
+--
+-- __/Commutativity/__
+--
+-- @
+-- 'commonSuffix' a b '==' 'commonSuffix' b a
 -- @
 --
 class (Monoid m, RightReductive m) => RightGCDMonoid m where

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -25,6 +25,7 @@ module Data.Monoid.GCD
     , LeftGCDMonoid (..)
     , RightGCDMonoid (..)
     , OverlappingGCDMonoid (..)
+    , DistributiveGCDMonoid
     , LeftDistributiveGCDMonoid
     , RightDistributiveGCDMonoid
     )
@@ -459,6 +460,32 @@ instance RightGCDMonoid LazyText.Text where
           stripCommonSuffix (LazyEncoding.encodeUtf8 x) (LazyEncoding.encodeUtf8 y)
     in (LazyEncoding.decodeUtf8 xlist, LazyEncoding.decodeUtf8 ylist, LazyEncoding.decodeUtf8 slist)
 #endif
+
+--------------------------------------------------------------------------------
+-- DistributiveGCDMonoid
+--------------------------------------------------------------------------------
+
+-- | Class of /commutative/ GCD monoids with /symmetric/ distributivity.
+--
+-- In addition to the general 'GCDMonoid' laws, instances of this class
+-- must also satisfy the following laws:
+--
+-- @
+-- 'gcd' (a '<>' b) (a '<>' c) '==' a '<>' 'gcd' b c
+-- @
+-- @
+-- 'gcd' (a '<>' c) (b '<>' c) '==' 'gcd' a b '<>' c
+-- @
+--
+class (LeftDistributiveGCDMonoid m, RightDistributiveGCDMonoid m, GCDMonoid m)
+    => DistributiveGCDMonoid m
+
+instance DistributiveGCDMonoid ()
+instance DistributiveGCDMonoid (Product Natural)
+instance DistributiveGCDMonoid (Sum Natural)
+instance DistributiveGCDMonoid IntSet.IntSet
+instance DistributiveGCDMonoid a => DistributiveGCDMonoid (Dual a)
+instance Ord a => DistributiveGCDMonoid (Set.Set a)
 
 -------------------------------------------------------------------------------
 -- LeftDistributiveGCDMonoid

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -85,6 +85,12 @@ import Prelude hiding (gcd)
 --     (c '==' 'gcd' a b)
 -- @
 --
+-- __/Idempotence/__
+--
+-- @
+-- 'gcd' a a '==' a
+-- @
+--
 class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, OverlappingGCDMonoid m) => GCDMonoid m where
    gcd :: m -> m -> m
 
@@ -106,6 +112,16 @@ class (Monoid m, Commutative m, Reductive m, LeftGCDMonoid m, RightGCDMonoid m, 
 -- and it cannot itself be a suffix of any other common prefix @y@ of both values:
 --
 -- > not (y `isPrefixOf` a && y `isPrefixOf` b && commonPrefix a b `isSuffixOf` y)
+--
+-- In addition, the 'commonPrefix' operation must satisfy the following
+-- properties:
+--
+-- __/Idempotence/__
+--
+-- @
+-- 'commonPrefix' a a '==' a
+-- @
+--
 class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
    commonPrefix :: m -> m -> m
    stripCommonPrefix :: m -> m -> (m, m, m)
@@ -136,6 +152,16 @@ class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
 -- and it cannot itself be a prefix of any other common suffix @y@ of both values:
 --
 -- > not (y `isSuffixOf` a && y `isSuffixOf` b && commonSuffix a b `isPrefixOf` y)
+--
+-- In addition, the 'commonSuffix' operation must satisfy the following
+-- properties:
+--
+-- __/Idempotence/__
+--
+-- @
+-- 'commonSuffix' a a '==' a
+-- @
+--
 class (Monoid m, RightReductive m) => RightGCDMonoid m where
    commonSuffix :: m -> m -> m
    stripCommonSuffix :: m -> m -> (m, m, m)

--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -9,17 +9,18 @@
 --
 -- The 'LCMMonoid' class is for Abelian, /i.e./, 'Commutative' monoids.
 --
-module Data.Monoid.LCM (
-    LCMMonoid (..)
+module Data.Monoid.LCM
+    ( LCMMonoid (..)
+    , DistributiveLCMMonoid
     )
-where
+    where
 
 import Prelude hiding (gcd, lcm, max)
 import qualified Prelude
 
 import Data.IntSet (IntSet)
 import Data.Monoid (Dual (..), Product (..), Sum (..))
-import Data.Monoid.GCD (GCDMonoid (..))
+import Data.Monoid.GCD (GCDMonoid (..), DistributiveGCDMonoid)
 import Data.Set (Set)
 import Numeric.Natural (Natural)
 import qualified Data.IntSet as IntSet
@@ -29,6 +30,10 @@ import qualified Data.Set as Set
 import Data.Maybe (isJust)
 import Data.Semigroup.Cancellative (Reductive ((</>)))
 import Data.Semigroup.Commutative (Commutative)
+
+--------------------------------------------------------------------------------
+-- LCMMonoid
+--------------------------------------------------------------------------------
 
 -- | Class of Abelian monoids that allow the /least common multiple/ to be
 --   found for any two given values.
@@ -141,3 +146,40 @@ instance (LCMMonoid a, LCMMonoid b, LCMMonoid c, LCMMonoid d) =>
   where
     lcm (a0, a1, a2, a3) (b0, b1, b2, b3) =
         (lcm a0 b0, lcm a1 b1, lcm a2 b2, lcm a3 b3)
+
+--------------------------------------------------------------------------------
+-- DistributiveLCMMonoid
+--------------------------------------------------------------------------------
+
+-- | Class of /commutative/ LCM monoids with /distributivity/.
+--
+-- In addition to the general 'LCMMonoid' laws, instances of this class
+-- must also satisfy the following laws:
+--
+-- The 'lcm' operation itself must be /both/ left-distributive /and/
+-- right-distributive:
+--
+-- @
+-- 'lcm' (a '<>' b) (a '<>' c) '==' a '<>' 'lcm' b c
+-- @
+-- @
+-- 'lcm' (a '<>' c) (b '<>' c) '==' 'lcm' a b '<>' c
+-- @
+--
+-- The 'lcm' and 'gcd' operations must distribute over one another:
+--
+-- @
+-- 'lcm' a ('gcd' b c) '==' 'gcd' ('lcm' a b) ('lcm' a c)
+-- @
+-- @
+-- 'gcd' a ('lcm' b c) '==' 'lcm' ('gcd' a b) ('gcd' a c)
+-- @
+--
+class (DistributiveGCDMonoid m, LCMMonoid m) => DistributiveLCMMonoid m
+
+instance DistributiveLCMMonoid ()
+instance DistributiveLCMMonoid (Product Natural)
+instance DistributiveLCMMonoid (Sum Natural)
+instance DistributiveLCMMonoid IntSet
+instance Ord a => DistributiveLCMMonoid (Set a)
+instance DistributiveLCMMonoid a => DistributiveLCMMonoid (Dual a)

--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -97,21 +97,6 @@ import Data.Semigroup.Commutative (Commutative)
 -- 'gcd' a ('lcm' a b) '==' a
 -- @
 --
--- __/Distributivity/__
---
--- @
--- 'lcm' (a '<>' b) (a '<>' c) '==' a '<>' 'lcm' b c
--- @
--- @
--- 'lcm' (a '<>' c) (b '<>' c) '==' 'lcm' a b '<>' c
--- @
--- @
--- 'lcm' a ('gcd' b c) '==' 'gcd' ('lcm' a b) ('lcm' a c)
--- @
--- @
--- 'gcd' a ('lcm' b c) '==' 'lcm' ('gcd' a b) ('gcd' a c)
--- @
---
 class GCDMonoid m => LCMMonoid m where
     lcm :: m -> m -> m
 

--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -7,7 +7,10 @@
 -- least monoid from which either argument can be subtracted with the '</>'
 -- operation.
 --
--- The 'LCMMonoid' class is for Abelian, /i.e./, 'Commutative' monoids.
+-- For LCM monoids that are distributive, this module also provides the
+-- 'DistributiveLCMMonoid' subclass of 'LCMMonoid'.
+--
+-- All classes in this module are for Abelian, /i.e./, 'Commutative' monoids.
 --
 module Data.Monoid.LCM
     ( LCMMonoid (..)

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -76,6 +76,15 @@ infix 5 <\>
 -- 'overlap' a a '==' a
 -- @
 --
+-- __/Identity/__
+--
+-- @
+-- 'overlap' 'mempty' a '==' 'mempty'
+-- @
+-- @
+-- 'overlap' a 'mempty' '==' 'mempty'
+-- @
+--
 class (Monoid m, LeftReductive m, RightReductive m) => OverlappingGCDMonoid m where
    stripPrefixOverlap :: m -> m -> m
    stripSuffixOverlap :: m -> m -> m

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -67,6 +67,15 @@ infix 5 <\>
 -- > ∀y. ((∀x. (x `isPrefixOf` b && x `isSuffixOf` a) => x `isPrefixOf` y && x `isSuffixOf` y) => y == overlap a b)
 --
 -- @since 1.0
+--
+-- In addition, the 'overlap' operation must satisfy the following properties:
+--
+-- __/Idempotence/__
+--
+-- @
+-- 'overlap' a a '==' a
+-- @
+--
 class (Monoid m, LeftReductive m, RightReductive m) => OverlappingGCDMonoid m where
    stripPrefixOverlap :: m -> m -> m
    stripSuffixOverlap :: m -> m -> m


### PR DESCRIPTION
This PR adds the following classes for **distributive** GCD and LCM monoids:

- `DistributiveLCMMonoid`
    - Subclass of `LCMMonoid` with distributivity.
- `DistributiveGCDMonoid`:
    - Subclass of `GCDMonoid` with distributivity.
- `LeftDistributiveGCDMonoid`:
    - Subclass of `LeftGCDMonoid` with left-distributivity.
- `RightDistributiveGCDMonoid`:
    - Subclass of `RightGCDMonoid` with right-distributivity.

In addition, this PR provides instances and tests for each of the above classes.

Finally, for consistency with `Data.Monoid.LCM`, this PR adds documentation and tests for the following properties of classes exported by `Data.Monoid.GCD`:
- _idempotence_
- _identity_
- _commutativity_
- _associativity_

The following diagram shows the extended class hierarchy ([source](https://www.yworks.com/yed-live/?file=https://gist.githubusercontent.com/jonathanknowles/a74a9e2a353e834c6b199c98937c9015/raw/15d49ed97cfeaad8465d87245cee0f2041b3aeac/Distributive%20GCD%20and%20LCM)), where an arrow to class `A` from class `B` indicates that `A` is a superclass of `B`:

![Screenshot from 2023-03-25 16-39-05](https://user-images.githubusercontent.com/206319/227831302-cf78e850-d2fa-4626-aaf8-41c9a1855276.png)

