### PR TITLE
Bump upper dependency bound for `commutative-semigroups`.

### DIFF
--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -46,7 +46,7 @@ Library
                      text >= 0.11 && < 1.3 || >= 2.0 && < 2.2,
                      primes == 0.2.*,
                      vector >= 0.12 && < 0.14,
-                     commutative-semigroups >= 0.1 && < 0.2
+                     commutative-semigroups >= 0.1 && < 0.3
   GHC-options:       -Wall
   default-language:  Haskell2010
 


### PR DESCRIPTION
This PR bumps the upper dependency bound for `commutative-semigroups` to allow building with version [`0.2`](https://hackage.haskell.org/package/commutative-semigroups-0.2) (the latest release).