### PR TITLE
More class instances for `Identity`. 

### DIFF
--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -231,6 +231,7 @@ factorialInstances :: [FactorialMonoidInstance]
 factorialInstances = map upcast stableFactorialInstances
                      ++ [FactorialMonoidInstance (mempty :: Sum Integer),
                          FactorialMonoidInstance (mempty :: Product Int32),
+                         FactorialMonoidInstance (mempty :: Identity String),
                          FactorialMonoidInstance (mempty :: Maybe String),
                          FactorialMonoidInstance (mempty :: (Text, String)),
                          FactorialMonoidInstance (mempty :: (Product Int32, ByteString, Sum Integer)),
@@ -338,6 +339,7 @@ reductiveInstances = map upcast cancellativeInstances
 
 overlappingGCDMonoidInstances = map upcast monusInstances
                                ++ [OverlappingGCDMonoidInstance (mempty :: String),
+                                   OverlappingGCDMonoidInstance (mempty :: Identity String),
                                    OverlappingGCDMonoidInstance (mempty :: Seq Int),
                                    OverlappingGCDMonoidInstance (mempty :: ByteString),
                                    OverlappingGCDMonoidInstance (mempty :: Lazy.ByteString),
@@ -350,6 +352,7 @@ overlappingGCDMonoidInstances = map upcast monusInstances
 
 monusInstances = [MonusInstance (mempty :: Product Natural),
                   MonusInstance (mempty :: Sum Natural),
+                  MonusInstance (mempty :: Identity (Sum Natural)),
                   MonusInstance (mempty :: Dual (Product Natural)),
                   MonusInstance (mempty :: Maybe ()),
                   MonusInstance (mempty :: Maybe (Product Natural)),
@@ -393,6 +396,7 @@ leftGCDInstances = map upcast gcdInstances
                        LeftGCDMonoidInstance (mempty :: Lazy.ByteString),
                        LeftGCDMonoidInstance (mempty :: Text),
                        LeftGCDMonoidInstance (mempty :: Lazy.Text),
+                       LeftGCDMonoidInstance (mempty :: Identity ByteString),
                        LeftGCDMonoidInstance (mempty :: Dual ByteString),
                        LeftGCDMonoidInstance (mempty :: (Text, String)),
                        LeftGCDMonoidInstance (mempty :: (ByteString, Text, String)),
@@ -415,6 +419,7 @@ rightGCDInstances = map upcast gcdInstances
                        RightGCDMonoidInstance (mempty :: Text),
                        RightGCDMonoidInstance (mempty :: Lazy.Text),
                        RightGCDMonoidInstance (mempty :: String),
+                       RightGCDMonoidInstance (mempty :: Identity ByteString),
                        RightGCDMonoidInstance (mempty :: Dual String),
                        RightGCDMonoidInstance (mempty :: (Seq Int, ByteString)),
                        RightGCDMonoidInstance (mempty :: Seq Int),
@@ -427,6 +432,7 @@ rightGCDInstances = map upcast gcdInstances
 gcdInstances =
     [ GCDMonoidInstance (mempty :: ())
     , GCDMonoidInstance (mempty :: Product Natural)
+    , GCDMonoidInstance (mempty :: Identity (Sum Natural))
     , GCDMonoidInstance (mempty :: Dual (Product Natural))
     , GCDMonoidInstance (mempty :: IntSet)
     , GCDMonoidInstance (mempty :: Set String)
@@ -441,6 +447,7 @@ distributiveGCDMonoidInstances =
     , DistributiveGCDMonoidInstance (mempty :: Set ())
     , DistributiveGCDMonoidInstance (mempty :: Set Bool)
     , DistributiveGCDMonoidInstance (mempty :: Set Word)
+    , DistributiveGCDMonoidInstance (mempty :: Identity (Sum Natural))
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set ()))
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set Bool))
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set Word))
@@ -471,6 +478,9 @@ leftDistributiveGCDMonoidInstances =
     , LeftDistributiveGCDMonoidInstance (mempty :: Set Bool)
     , LeftDistributiveGCDMonoidInstance (mempty :: Set Word)
       -- Instances for monoid transformers:
+    , LeftDistributiveGCDMonoidInstance (mempty :: Identity [()])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Identity [Bool])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Identity [Word])
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [()])
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Word])
@@ -501,6 +511,9 @@ rightDistributiveGCDMonoidInstances =
     , RightDistributiveGCDMonoidInstance (mempty :: Set Bool)
     , RightDistributiveGCDMonoidInstance (mempty :: Set Word)
       -- Instances for monoid transformers:
+    , RightDistributiveGCDMonoidInstance (mempty :: Identity [()])
+    , RightDistributiveGCDMonoidInstance (mempty :: Identity [Bool])
+    , RightDistributiveGCDMonoidInstance (mempty :: Identity [Word])
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [()])
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [Word])
@@ -509,6 +522,7 @@ rightDistributiveGCDMonoidInstances =
 lcmInstances =
     [LCMMonoidInstance (mempty :: Product Natural),
      LCMMonoidInstance (mempty :: Sum Natural),
+     LCMMonoidInstance (mempty :: Identity (Sum Natural)),
      LCMMonoidInstance (mempty :: Dual (Product Natural)),
      LCMMonoidInstance (mempty :: Dual (Sum Natural)),
      LCMMonoidInstance (mempty :: IntSet),
@@ -530,6 +544,7 @@ distributiveLCMInstances =
     , DistributiveLCMMonoidInstance (mempty :: Set ())
     , DistributiveLCMMonoidInstance (mempty :: Set Bool)
     , DistributiveLCMMonoidInstance (mempty :: Set Word)
+    , DistributiveLCMMonoidInstance (mempty :: Identity (Sum Natural))
     , DistributiveLCMMonoidInstance (mempty :: Dual (Product Natural))
     , DistributiveLCMMonoidInstance (mempty :: Dual (Sum Natural))
     ]

--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -1,4 +1,4 @@
-{- 
+{-
     Copyright 2013-2019 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
@@ -70,7 +70,7 @@ import qualified Data.Monoid.Instances.Positioned as Positioned
 import Data.Semigroup (Semigroup, (<>), Max, Min)
 import Data.Monoid (Monoid, mempty, mconcat, All(All), Any(Any), Dual(Dual),
                     First(First), Last(Last), Sum(Sum), Product(Product))
-import Data.Semigroup.Factorial (Factorial, StableFactorial, 
+import Data.Semigroup.Factorial (Factorial, StableFactorial,
                                  factors, primePrefix, primeSuffix, foldl, foldl', foldr, length, reverse)
 import Data.Semigroup.Cancellative (Commutative, Reductive,
                                     LeftReductive, RightReductive,
@@ -247,7 +247,7 @@ factorialInstances = map upcast stableFactorialInstances
    where upcast (StableFactorialMonoidInstance i) = FactorialMonoidInstance i
 
 stableFactorialInstances :: [StableFactorialMonoidInstance]
-stableFactorialInstances = stable1 ++ map measure stable1 ++ map prefixed stable1 ++ map position stable1 
+stableFactorialInstances = stable1 ++ map measure stable1 ++ map prefixed stable1 ++ map position stable1
    where stable1 = map upcast stableTextualInstances
                    ++ [StableFactorialMonoidInstance (mempty :: ByteString),
                        StableFactorialMonoidInstance (mempty :: Lazy.ByteString),
@@ -257,7 +257,7 @@ stableFactorialInstances = stable1 ++ map measure stable1 ++ map prefixed stable
          upcast (StableTextualMonoidInstance i) = StableFactorialMonoidInstance i
          measure (StableFactorialMonoidInstance i) = StableFactorialMonoidInstance (Measured.measure i)
          prefixed (StableFactorialMonoidInstance i) = StableFactorialMonoidInstance (PrefixMemory.shadowed i)
-         position (StableFactorialMonoidInstance (i :: a)) = 
+         position (StableFactorialMonoidInstance (i :: a)) =
             StableFactorialMonoidInstance (pure i :: OffsetPositioned a)
 
 textualInstances :: [TextualMonoidInstance]
@@ -282,7 +282,7 @@ stableTextualInstances = stable1 ++ map measure stable1 ++ map prefixed stable1 
                     StableTextualMonoidInstance (mempty :: Vector Char)]
          measure (StableTextualMonoidInstance i) = StableTextualMonoidInstance (Measured.measure i)
          prefixed (StableTextualMonoidInstance i) = StableTextualMonoidInstance (PrefixMemory.shadowed i)
-         position (StableTextualMonoidInstance (i :: a)) = 
+         position (StableTextualMonoidInstance (i :: a)) =
             [StableTextualMonoidInstance (pure i :: OffsetPositioned a),
              StableTextualMonoidInstance (pure i :: LinePositioned a)]
 
@@ -547,14 +547,14 @@ checkInstances (TextualTest checkType) = (map checkType textualInstances)
 checkInstances (LeftReductiveTest checkType) = (map checkType leftReductiveInstances)
 checkInstances (RightReductiveTest checkType) = (map checkType rightReductiveInstances)
 checkInstances (ReductiveTest checkType) = (map checkType reductiveInstances)
-checkInstances (LeftCancellativeTest checkType) = (map checkType leftCancellativeInstances) 
-checkInstances (RightCancellativeTest checkType) = (map checkType rightCancellativeInstances) 
-checkInstances (CancellativeTest checkType) = (map checkType cancellativeInstances) 
+checkInstances (LeftCancellativeTest checkType) = (map checkType leftCancellativeInstances)
+checkInstances (RightCancellativeTest checkType) = (map checkType rightCancellativeInstances)
+checkInstances (CancellativeTest checkType) = (map checkType cancellativeInstances)
 checkInstances (OverlappingGCDTest checkType) = (map checkType overlappingGCDMonoidInstances)
 checkInstances (MonusTest checkType) = (map checkType monusInstances)
-checkInstances (LeftGCDTest checkType) = (map checkType leftGCDInstances) 
-checkInstances (RightGCDTest checkType) = (map checkType rightGCDInstances) 
-checkInstances (GCDTest checkType) = (map checkType gcdInstances)  
+checkInstances (LeftGCDTest checkType) = (map checkType leftGCDInstances)
+checkInstances (RightGCDTest checkType) = (map checkType rightGCDInstances)
+checkInstances (GCDTest checkType) = (map checkType gcdInstances)
 checkInstances (DistributiveGCDTest checkType) = (map checkType distributiveGCDMonoidInstances)
 checkInstances (LeftDistributiveGCDTest checkType) = (map checkType leftDistributiveGCDMonoidInstances)
 checkInstances (RightDistributiveGCDTest checkType) = (map checkType rightDistributiveGCDMonoidInstances)
@@ -705,16 +705,16 @@ checkConcatFactors (FactorialMonoidInstance (e :: a)) = null (factors e) .&&. fo
 checkFactorsOfFactors (FactorialMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen a) (all singleton . factors)
    where singleton prime = factors prime == [prime]
 
-checkSplitPrimePrefix (FactorialMonoidInstance (_ :: a)) = 
+checkSplitPrimePrefix (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> factors a == unfoldr splitPrimePrefix a)
 
 checkSplitPrimeSuffix (FactorialMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen a) check
    where check a = factors a == reverse (unfoldr (fmap swap . splitPrimeSuffix) a)
 
-checkPrimePrefix (FactorialMonoidInstance (_ :: a)) = 
+checkPrimePrefix (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> primePrefix a == maybe mempty fst (splitPrimePrefix a))
 
-checkPrimeSuffix (FactorialMonoidInstance (_ :: a)) = 
+checkPrimeSuffix (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> primeSuffix a == maybe mempty snd (splitPrimeSuffix a))
 
 checkInits (FactorialMonoidInstance (_ :: a)) =
@@ -723,16 +723,16 @@ checkInits (FactorialMonoidInstance (_ :: a)) =
 checkTails (FactorialMonoidInstance (_ :: a)) =
    mapSize (`div` 5) $ forAll (arbitrary :: Gen a) (\a-> tails a == List.map mconcat (List.tails $ factors a))
 
-checkLeftFold (FactorialMonoidInstance (_ :: a)) = 
+checkLeftFold (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> foldl (flip (:)) [] a == List.foldl (flip (:)) [] (factors a))
 
-checkLeftFold' (FactorialMonoidInstance (_ :: a)) = 
+checkLeftFold' (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> foldl' (flip (:)) [] a == List.foldl' (flip (:)) [] (factors a))
 
-checkRightFold (FactorialMonoidInstance (_ :: a)) = 
+checkRightFold (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> foldr (:) [] a == List.foldr (:) [] (factors a))
 
-checkLength (FactorialMonoidInstance (_ :: a)) = 
+checkLength (FactorialMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) (\a-> length a == List.length (factors a))
 
 checkSpan (FactorialMonoidInstance (_ :: a)) = property $ \p-> forAll (arbitrary :: Gen a) (check p)
@@ -755,19 +755,19 @@ checkSplitAt (FactorialMonoidInstance (_ :: a)) = property $ \i-> forAll (arbitr
    where check i a = splitAt i a == (mconcat l, mconcat r)
             where (l, r) = List.splitAt i (factors a)
 
-checkReverse (FactorialMonoidInstance (_ :: a)) = 
+checkReverse (FactorialMonoidInstance (_ :: a)) =
    property $ forAll (arbitrary :: Gen a) (\a-> reverse a == mconcat (List.reverse $ factors a))
 
 checkStability (StableFactorialMonoidInstance (_ :: a)) =
    property $ forAll (arbitrary :: Gen (a, a)) (\(a, b)-> factors (a <> b) == factors a <> factors b)
 
-checkFromText (TextualMonoidInstance (_ :: a)) = 
+checkFromText (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen Text) (\t-> Textual.fromText t == (fromString (Text.unpack t) :: a))
 
-checkSingleton (TextualMonoidInstance (_ :: a)) = 
+checkSingleton (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen Char) (\c-> Textual.singleton c == (fromString [c] :: a))
 
-checkSplitCharacterPrefix (TextualMonoidInstance (_ :: a)) = 
+checkSplitCharacterPrefix (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen String) check1 .&&. forAll (arbitrary :: Gen a) check2
    where check1 s = unfoldr Textual.splitCharacterPrefix (fromString s :: a) == s
          check2 t = Textual.splitCharacterPrefix (primePrefix t)
@@ -785,7 +785,7 @@ checkUnfoldrToFactors (TextualMonoidInstance (_ :: a)) = forAll (arbitrary :: Ge
 checkFactorsFromString (TextualMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen String) check
    where check s = unfoldr Textual.splitCharacterPrefix (fromString s :: a) == s
 
-checkTextualMap (TextualMonoidInstance (_ :: a)) = 
+checkTextualMap (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.map wrapSucc a == Textual.concatMap (Textual.singleton . wrapSucc) a
                     && Textual.map id a == a
@@ -794,7 +794,7 @@ checkTextualMap (TextualMonoidInstance (_ :: a)) =
             | c == maxBound = minBound
             | otherwise = succ c
 
-checkConcatMap (TextualMonoidInstance (_ :: a)) = 
+checkConcatMap (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.concatMap (fromString . f) a == mconcat (map apply $ factors a)
                     && Textual.concatMap Textual.singleton a == a
@@ -808,19 +808,19 @@ checkAll (TextualMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen a) check
 checkAny (TextualMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen a) check
    where check a = Textual.any isLetter a == Textual.foldr (const id) ((||) . isLetter) False a
 
-checkTextualFoldl (TextualMonoidInstance (_ :: a)) = 
+checkTextualFoldl (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.foldl (\l a-> Left a : l) (\l c-> Right c : l) [] a == List.reverse (textualFactors a)
                     && Textual.foldl (<>) (\a-> (a <>) . Textual.singleton) mempty a == a
          check2 s = Textual.foldl undefined (flip (:)) [] s == List.foldl (flip (:)) [] s
 
-checkTextualFoldr (TextualMonoidInstance (_ :: a)) = 
+checkTextualFoldr (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.foldr (\a l-> Left a : l) (\c l-> Right c : l) [] a == textualFactors a
                     && Textual.foldr (<>) ((<>) . Textual.singleton) mempty a == a
          check2 s = Textual.foldr undefined (:) [] (fromString s :: a) == s
 
-checkTextualFoldl' (TextualMonoidInstance (_ :: a)) = 
+checkTextualFoldl' (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.foldl' (\l a-> Left a : l) (\l c-> Right c : l) [] a == List.reverse (textualFactors a)
                     && Textual.foldl' (<>) (\a-> (a <>) . Textual.singleton) mempty a == a
@@ -879,28 +879,28 @@ checkToText (TextualMonoidInstance (_ :: a)) =
    where check1 a = forAll arbitrary $ \f-> Textual.toText f a == Textual.foldr (\t s-> f t <> s) Text.cons Text.empty a
          check2 s = Textual.toText undefined (Textual.fromText s :: a) == s
 
-checkTextualMapAccumL (TextualMonoidInstance (_ :: a)) = 
+checkTextualMapAccumL (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = uncurry (Textual.mapAccumL (,)) ((), a) == ((), a)
          check2 s = Textual.mapAccumL f c (fromString s :: a) == fmap fromString (List.mapAccumL f c s)
          c = 0 :: Int
          f n c = if isLetter c then (succ n, succ c) else (2*n, c)
 
-checkTextualMapAccumR (TextualMonoidInstance (_ :: a)) = 
+checkTextualMapAccumR (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = uncurry (Textual.mapAccumR (,)) ((), a) == ((), a)
          check2 s = Textual.mapAccumR f c (fromString s :: a) == fmap fromString (List.mapAccumR f c s)
          c = 0 :: Int
          f n c = if isLetter c then (succ n, succ c) else (2*n, c)
 
-checkTextualTakeWhile (TextualMonoidInstance (_ :: a)) = 
+checkTextualTakeWhile (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = textualFactors (Textual.takeWhile (const True) isLetter a)
                     == List.takeWhile (either (const True) isLetter) (textualFactors a)
                     && Textual.takeWhile (const True) (const True) a == a
          check2 s = Textual.takeWhile undefined isLetter (fromString s :: a) == fromString (List.takeWhile isLetter s)
 
-checkTextualDropWhile (TextualMonoidInstance (_ :: a)) = 
+checkTextualDropWhile (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = textualFactors (Textual.dropWhile (const True) isLetter a)
                     == List.dropWhile (either (const True) isLetter) (textualFactors a)
@@ -953,14 +953,14 @@ checkTextualSpanMaybe_' (TextualMonoidInstance (_ :: a)) =
                   foldMaybe = Textual.foldl_' gc (Just s0)
                   gc s c = s >>= flip fc c
 
-checkTextualTakeWhile_ (TextualMonoidInstance (_ :: a)) = 
+checkTextualTakeWhile_ (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = textualFactors (Textual.takeWhile_ True isLetter a)
                     == List.takeWhile (either (const True) isLetter) (textualFactors a)
                     && Textual.takeWhile_ True (const True) a == a
          check2 s = Textual.takeWhile_ undefined isLetter (fromString s :: a) == fromString (List.takeWhile isLetter s)
 
-checkTextualDropWhile_ (TextualMonoidInstance (_ :: a)) = 
+checkTextualDropWhile_ (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = textualFactors (Textual.dropWhile_ True isLetter a)
                     == List.dropWhile (either (const True) isLetter) (textualFactors a)
@@ -972,7 +972,7 @@ checkTextualSplit (TextualMonoidInstance (_ :: a)) = forAll (arbitrary :: Gen a)
    where check a = List.all (List.all isLetter . rights . textualFactors) (Textual.split (not . isLetter) a)
                    && (mconcat . intersperse (fromString " ") . Textual.split (== ' ')) a == a
 
-checkTextualFind (TextualMonoidInstance (_ :: a)) = 
+checkTextualFind (TextualMonoidInstance (_ :: a)) =
    forAll (arbitrary :: Gen a) check1 .&&. forAll (arbitrary :: Gen String) check2
    where check1 a = Textual.find isLetter a == (List.find isLetter . rights . textualFactors) a
          check2 s = Textual.find isLetter (fromString s :: a) == List.find isLetter s
@@ -1308,7 +1308,7 @@ textualFactors :: TextualMonoid t => t -> [Either t Char]
 textualFactors = map characterize . factors
    where characterize prime = maybe (Left prime) Right (Textual.characterPrefix prime)
 
-newtype TestString = TestString String deriving (Eq, Show, Arbitrary, CoArbitrary, 
+newtype TestString = TestString String deriving (Eq, Show, Arbitrary, CoArbitrary,
                                                  Semigroup, LeftReductive, LeftCancellative, StableFactorial,
                                                  Monoid, LeftGCDMonoid,
                                                  MonoidNull, PositiveMonoid, IsString)

--- a/src/Data/Monoid/Factorial.hs
+++ b/src/Data/Monoid/Factorial.hs
@@ -1,11 +1,11 @@
-{- 
+{-
     Copyright 2013-2017 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
 -}
 
 -- | This module defines the 'FactorialMonoid' class and some of its instances.
--- 
+--
 
 {-# LANGUAGE Haskell2010, ConstraintKinds, FlexibleInstances, Trustworthy #-}
 
@@ -46,9 +46,9 @@ import Prelude hiding (break, drop, dropWhile, foldl, foldr, last, length, map, 
 -- Factors of a list are /not/ its elements but all its single-item sublists:
 --
 -- prop> factors "abc" == ["a", "b", "c"]
--- 
+--
 -- The methods of this class satisfy the following laws in addition to those of 'Factorial':
--- 
+--
 -- > null == List.null . factors
 -- > factors == unfoldr splitPrimePrefix == List.reverse . unfoldr (fmap swap . splitPrimeSuffix)
 -- > reverse == mconcat . List.reverse . factors

--- a/src/Data/Monoid/Factorial.hs
+++ b/src/Data/Monoid/Factorial.hs
@@ -8,6 +8,8 @@
 --
 
 {-# LANGUAGE Haskell2010, ConstraintKinds, FlexibleInstances, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Monoid.Factorial (
    module Data.Semigroup.Factorial,
@@ -16,6 +18,7 @@ module Data.Monoid.Factorial (
 where
 
 import Control.Arrow (first)
+import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid (..), Dual(..), Sum(..), Product(..), Endo(Endo, appEndo))
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
@@ -162,6 +165,8 @@ type StableFactorialMonoid m = (StableFactorial m, FactorialMonoid m, PositiveMo
 instance FactorialMonoid () where
    splitPrimePrefix () = Nothing
    splitPrimeSuffix () = Nothing
+
+deriving instance FactorialMonoid a => FactorialMonoid (Identity a)
 
 instance FactorialMonoid a => FactorialMonoid (Dual a) where
    splitPrimePrefix (Dual a) = case splitPrimeSuffix a

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -49,6 +49,8 @@
 --     Subclass of 'RightGCDMonoid' with /right/-distributivity.
 --
 {-# LANGUAGE CPP, Haskell2010, FlexibleInstances, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Monoid.GCD
     ( GCDMonoid (..)
@@ -63,6 +65,7 @@ module Data.Monoid.GCD
 
 import qualified Prelude
 
+import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Unsafe as ByteString
@@ -284,6 +287,12 @@ instance LeftGCDMonoid () where
 -- | /O(1)/
 instance RightGCDMonoid () where
    commonSuffix () () = ()
+
+-- Identity instances
+
+deriving instance GCDMonoid a => GCDMonoid (Identity a)
+deriving instance LeftGCDMonoid a => LeftGCDMonoid (Identity a)
+deriving instance RightGCDMonoid a => RightGCDMonoid (Identity a)
 
 -- Dual instances
 
@@ -617,6 +626,7 @@ class (LeftDistributiveGCDMonoid m, RightDistributiveGCDMonoid m, GCDMonoid m)
     => DistributiveGCDMonoid m
 
 instance DistributiveGCDMonoid ()
+instance DistributiveGCDMonoid a => DistributiveGCDMonoid (Identity a)
 instance DistributiveGCDMonoid (Product Natural)
 instance DistributiveGCDMonoid (Sum Natural)
 instance DistributiveGCDMonoid IntSet.IntSet
@@ -655,6 +665,7 @@ instance LeftDistributiveGCDMonoid IntSet.IntSet
 instance Ord a => LeftDistributiveGCDMonoid (Set.Set a)
 
 -- Instances for monoid transformers:
+instance LeftDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Identity a)
 instance RightDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Dual a)
 
 --------------------------------------------------------------------------------
@@ -689,4 +700,5 @@ instance RightDistributiveGCDMonoid IntSet.IntSet
 instance Ord a => RightDistributiveGCDMonoid (Set.Set a)
 
 -- Instances for monoid transformers:
+instance RightDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Identity a)
 instance LeftDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Dual a)

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -1,4 +1,4 @@
-{- 
+{-
     Copyright 2013-2019 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
@@ -210,7 +210,7 @@ class (Monoid m, LeftReductive m) => LeftGCDMonoid m where
 
 -- | Class of monoids capable of finding the equivalent of greatest common divisor on the right side of two monoidal
 -- values. The following laws must be respected:
--- 
+--
 -- > stripCommonSuffix a b == (a', b', s)
 -- >    where s = commonSuffix a b
 -- >          Just a' = stripSuffix p a

--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE Haskell2010, FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- | This module defines the 'LCMMonoid' subclass of the 'Monoid' class.
 --
@@ -21,6 +23,7 @@ module Data.Monoid.LCM
 import Prelude hiding (gcd, lcm, max)
 import qualified Prelude
 
+import Data.Functor.Identity (Identity (Identity))
 import Data.IntSet (IntSet)
 import Data.Monoid (Dual (..), Product (..), Sum (..))
 import Data.Monoid.GCD (GCDMonoid (..), DistributiveGCDMonoid)
@@ -106,6 +109,8 @@ class GCDMonoid m => LCMMonoid m where
 instance LCMMonoid () where
     lcm () () = ()
 
+deriving instance LCMMonoid a => LCMMonoid (Identity a)
+
 instance LCMMonoid a => LCMMonoid (Dual a) where
     lcm (Dual a) (Dual b) = Dual (lcm a b)
 
@@ -166,6 +171,7 @@ instance (LCMMonoid a, LCMMonoid b, LCMMonoid c, LCMMonoid d) =>
 class (DistributiveGCDMonoid m, LCMMonoid m) => DistributiveLCMMonoid m
 
 instance DistributiveLCMMonoid ()
+instance DistributiveLCMMonoid a => DistributiveLCMMonoid (Identity a)
 instance DistributiveLCMMonoid (Product Natural)
 instance DistributiveLCMMonoid (Sum Natural)
 instance DistributiveLCMMonoid IntSet

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -1,4 +1,4 @@
-{- 
+{-
     Copyright 2013-2019 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
@@ -14,7 +14,7 @@ module Data.Monoid.Monus (
    Monus(..), OverlappingGCDMonoid(..)
    )
 where
-   
+
 import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -9,12 +9,15 @@
 -- @since 1.0
 
 {-# LANGUAGE Haskell2010, FlexibleInstances, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Monoid.Monus (
    Monus(..), OverlappingGCDMonoid(..)
    )
 where
 
+import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -132,6 +135,11 @@ instance OverlappingGCDMonoid () where
    stripOverlap () () = ((), (), ())
    stripPrefixOverlap () () = ()
    stripSuffixOverlap () () = ()
+
+-- Identity instances
+
+deriving instance Monus a => Monus (Identity a)
+deriving instance OverlappingGCDMonoid a => OverlappingGCDMonoid (Identity a)
 
 -- Dual instances
 

--- a/src/Data/Monoid/Null.hs
+++ b/src/Data/Monoid/Null.hs
@@ -8,6 +8,8 @@
 --
 
 {-# LANGUAGE Haskell2010, CPP, FlexibleInstances, DefaultSignatures, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Monoid.Null (
    MonoidNull(..), PositiveMonoid
@@ -144,8 +146,7 @@ instance MonoidNull r => MonoidNull (Const r a) where
    null (Const r) = null r
 
 -- | @since 1.2.5.0
-instance MonoidNull a => MonoidNull (Identity a) where
-   null (Identity a) = null a
+deriving instance MonoidNull a => MonoidNull (Identity a)
 
 -- | @since 1.2.5.0
 instance MonoidNull a => MonoidNull (WrappedMonoid a) where

--- a/src/Data/Semigroup/Cancellative.hs
+++ b/src/Data/Semigroup/Cancellative.hs
@@ -27,6 +27,8 @@
 -- * 'RightCancellative'
 
 {-# LANGUAGE Haskell2010, FlexibleInstances, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Semigroup.Cancellative (
    -- * Symmetric, commutative semigroup classes
@@ -248,24 +250,19 @@ instance RightReductive All where
 
 -- Identity & Const instances
 
-instance Reductive a => Reductive (Identity a) where
-   Identity a </> Identity b = Identity <$> (a </> b)
+deriving instance Reductive a => Reductive (Identity a)
 instance Reductive a => Reductive (Const a x) where
    Const a </> Const b = Const <$> (a </> b)
 
 instance Cancellative a => Cancellative (Identity a)
 instance Cancellative a => Cancellative (Const a x)
 
-instance LeftReductive a => LeftReductive (Identity a) where
-   stripPrefix (Identity a) (Identity b) = Identity <$> stripPrefix a b
-   isPrefixOf (Identity a) (Identity b) = isPrefixOf a b
+deriving instance LeftReductive a => LeftReductive (Identity a)
 instance LeftReductive a => LeftReductive (Const a x) where
    stripPrefix (Const a) (Const b) = Const <$> stripPrefix a b
    isPrefixOf (Const a) (Const b) = isPrefixOf a b
 
-instance RightReductive a => RightReductive (Identity a) where
-   stripSuffix (Identity a) (Identity b) = Identity <$> stripSuffix a b
-   isSuffixOf (Identity a) (Identity b) = isSuffixOf a b
+deriving instance RightReductive a => RightReductive (Identity a)
 instance RightReductive a => RightReductive (Const a x) where
    stripSuffix (Const a) (Const b) = Const <$> stripSuffix a b
    isSuffixOf (Const a) (Const b) = isSuffixOf a b

--- a/src/Data/Semigroup/Cancellative.hs
+++ b/src/Data/Semigroup/Cancellative.hs
@@ -1,4 +1,4 @@
-{- 
+{-
     Copyright 2013-2019 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
@@ -17,13 +17,13 @@
 --
 -- All semigroup subclasses listed above are for Abelian, /i.e./, commutative or symmetric semigroups. Since most
 -- practical semigroups in Haskell are not Abelian, each of the these classes has two symmetric superclasses:
--- 
+--
 -- * 'LeftReductive'
--- 
+--
 -- * 'LeftCancellative'
--- 
+--
 -- * 'RightReductive'
--- 
+--
 -- * 'RightCancellative'
 
 {-# LANGUAGE Haskell2010, FlexibleInstances, Trustworthy #-}
@@ -59,7 +59,7 @@ import Numeric.Product.Commutative (CommutativeProduct)
 
 -- | Class of Abelian semigroups with a partial inverse for the Semigroup '<>' operation. The inverse operation '</>' must
 -- satisfy the following laws:
--- 
+--
 -- > maybe a (b <>) (a </> b) == a
 -- > maybe a (<> b) (a </> b) == a
 --
@@ -81,11 +81,11 @@ infix 5 </>
 class (LeftCancellative m, RightCancellative m, Reductive m) => Cancellative m
 
 -- | Class of semigroups with a left inverse of 'Data.Semigroup.<>', satisfying the following law:
--- 
+--
 -- > isPrefixOf a b == isJust (stripPrefix a b)
 -- > maybe b (a <>) (stripPrefix a b) == b
 -- > a `isPrefixOf` (a <> b)
--- 
+--
 -- Every instance definition has to implement at least the 'stripPrefix' method.
 class Semigroup m => LeftReductive m where
    isPrefixOf :: m -> m -> Bool
@@ -95,11 +95,11 @@ class Semigroup m => LeftReductive m where
    {-# MINIMAL stripPrefix #-}
 
 -- | Class of semigroups with a right inverse of 'Data.Semigroup.<>', satisfying the following law:
--- 
+--
 -- > isSuffixOf a b == isJust (stripSuffix a b)
 -- > maybe b (<> a) (stripSuffix a b) == b
 -- > b `isSuffixOf` (a <> b)
--- 
+--
 -- Every instance definition has to implement at least the 'stripSuffix' method.
 class Semigroup m => RightReductive m where
    isSuffixOf :: m -> m -> Bool

--- a/src/Data/Semigroup/Factorial.hs
+++ b/src/Data/Semigroup/Factorial.hs
@@ -8,6 +8,8 @@
 --
 
 {-# LANGUAGE Haskell2010, FlexibleInstances, Trustworthy #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module Data.Semigroup.Factorial (
    -- * Classes
@@ -18,6 +20,7 @@ module Data.Semigroup.Factorial (
 where
 
 import qualified Control.Monad as Monad
+import Data.Functor.Identity (Identity (Identity))
 import Data.Semigroup -- (Semigroup (..), Dual(..), Sum(..), Product(..), Endo(Endo, appEndo))
 import qualified Data.Foldable as Foldable
 import qualified Data.List as List
@@ -116,6 +119,8 @@ instance Factorial () where
    primeSuffix () = ()
    length () = 0
    reverse = id
+
+deriving instance Factorial a => Factorial (Identity a)
 
 instance Factorial a => Factorial (Dual a) where
    factors (Dual a) = fmap Dual (reverse $ factors a)

--- a/src/Data/Semigroup/Factorial.hs
+++ b/src/Data/Semigroup/Factorial.hs
@@ -1,11 +1,11 @@
-{- 
+{-
     Copyright 2013-2019 Mario Blazevic
 
     License: BSD3 (see BSD3-LICENSE.txt file)
 -}
 
 -- | This module defines the 'Semigroup' => 'Factorial' => 'StableFactorial' classes and some of their instances.
--- 
+--
 
 {-# LANGUAGE Haskell2010, FlexibleInstances, Trustworthy #-}
 
@@ -50,9 +50,9 @@ import Prelude (Int, Maybe(..), Eq, Ord, Monoid, Applicative, Monad, Integral,
 -- Factors of a list are /not/ its elements but all its single-item sublists:
 --
 -- prop> factors "abc" == ["a", "b", "c"]
--- 
+--
 -- The methods of this class satisfy the following laws:
--- 
+--
 -- > maybe id sconcat  . nonEmpty . factors == id
 -- > List.all (\prime-> factors prime == [prime]) . factors
 -- > primePrefix s == foldr const s s


### PR DESCRIPTION
This PR defines more class instances for the [`Identity`](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Functor-Identity.html#t:Identity) type.

The approach used is similar to `base`, which uses [`GeneralizedNewtypeDeriving`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/newtype_deriving.html) to auto-derive instances of `Semigroup` and `Monoid` for `Identity`:

```hs
newtype Identity a = Identity { runIdentity :: a }
    deriving ( ...
             , Semigroup  -- ^ @since base-4.9.0.0
             , Monoid     -- ^ @since base-4.9.0.0
             , ...
             )
```
(See source [here](https://hackage.haskell.org/package/ghc-internal-9.1201.0/docs/src/GHC.Internal.Data.Functor.Identity.html#Identity).)

In addition, this PR:
- uses `GeneralizedNewtypeDeriving` to simplify the remaining existing class instances for `Identity`.
- adds basic test coverage for all `Identity` class instances.