### PR TITLE
More class instances for `Const`. 

### DIFF
--- a/Test/TestMonoidSubclasses.hs
+++ b/Test/TestMonoidSubclasses.hs
@@ -232,6 +232,7 @@ factorialInstances = map upcast stableFactorialInstances
                      ++ [FactorialMonoidInstance (mempty :: Sum Integer),
                          FactorialMonoidInstance (mempty :: Product Int32),
                          FactorialMonoidInstance (mempty :: Identity String),
+                         FactorialMonoidInstance (mempty :: Const String Int),
                          FactorialMonoidInstance (mempty :: Maybe String),
                          FactorialMonoidInstance (mempty :: (Text, String)),
                          FactorialMonoidInstance (mempty :: (Product Int32, ByteString, Sum Integer)),
@@ -340,6 +341,7 @@ reductiveInstances = map upcast cancellativeInstances
 overlappingGCDMonoidInstances = map upcast monusInstances
                                ++ [OverlappingGCDMonoidInstance (mempty :: String),
                                    OverlappingGCDMonoidInstance (mempty :: Identity String),
+                                   OverlappingGCDMonoidInstance (mempty :: Const String Int),
                                    OverlappingGCDMonoidInstance (mempty :: Seq Int),
                                    OverlappingGCDMonoidInstance (mempty :: ByteString),
                                    OverlappingGCDMonoidInstance (mempty :: Lazy.ByteString),
@@ -353,6 +355,7 @@ overlappingGCDMonoidInstances = map upcast monusInstances
 monusInstances = [MonusInstance (mempty :: Product Natural),
                   MonusInstance (mempty :: Sum Natural),
                   MonusInstance (mempty :: Identity (Sum Natural)),
+                  MonusInstance (mempty :: Const (Sum Natural) Int),
                   MonusInstance (mempty :: Dual (Product Natural)),
                   MonusInstance (mempty :: Maybe ()),
                   MonusInstance (mempty :: Maybe (Product Natural)),
@@ -397,6 +400,7 @@ leftGCDInstances = map upcast gcdInstances
                        LeftGCDMonoidInstance (mempty :: Text),
                        LeftGCDMonoidInstance (mempty :: Lazy.Text),
                        LeftGCDMonoidInstance (mempty :: Identity ByteString),
+                       LeftGCDMonoidInstance (mempty :: Const ByteString Int),
                        LeftGCDMonoidInstance (mempty :: Dual ByteString),
                        LeftGCDMonoidInstance (mempty :: (Text, String)),
                        LeftGCDMonoidInstance (mempty :: (ByteString, Text, String)),
@@ -420,6 +424,7 @@ rightGCDInstances = map upcast gcdInstances
                        RightGCDMonoidInstance (mempty :: Lazy.Text),
                        RightGCDMonoidInstance (mempty :: String),
                        RightGCDMonoidInstance (mempty :: Identity ByteString),
+                       RightGCDMonoidInstance (mempty :: Const ByteString Int),
                        RightGCDMonoidInstance (mempty :: Dual String),
                        RightGCDMonoidInstance (mempty :: (Seq Int, ByteString)),
                        RightGCDMonoidInstance (mempty :: Seq Int),
@@ -433,6 +438,7 @@ gcdInstances =
     [ GCDMonoidInstance (mempty :: ())
     , GCDMonoidInstance (mempty :: Product Natural)
     , GCDMonoidInstance (mempty :: Identity (Sum Natural))
+    , GCDMonoidInstance (mempty :: Const (Sum Natural) Int)
     , GCDMonoidInstance (mempty :: Dual (Product Natural))
     , GCDMonoidInstance (mempty :: IntSet)
     , GCDMonoidInstance (mempty :: Set String)
@@ -448,6 +454,7 @@ distributiveGCDMonoidInstances =
     , DistributiveGCDMonoidInstance (mempty :: Set Bool)
     , DistributiveGCDMonoidInstance (mempty :: Set Word)
     , DistributiveGCDMonoidInstance (mempty :: Identity (Sum Natural))
+    , DistributiveGCDMonoidInstance (mempty :: Const (Sum Natural) Int)
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set ()))
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set Bool))
     , DistributiveGCDMonoidInstance (mempty :: Dual (Set Word))
@@ -481,6 +488,9 @@ leftDistributiveGCDMonoidInstances =
     , LeftDistributiveGCDMonoidInstance (mempty :: Identity [()])
     , LeftDistributiveGCDMonoidInstance (mempty :: Identity [Bool])
     , LeftDistributiveGCDMonoidInstance (mempty :: Identity [Word])
+    , LeftDistributiveGCDMonoidInstance (mempty :: Const [()] Int)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Const [Bool] Int)
+    , LeftDistributiveGCDMonoidInstance (mempty :: Const [Word] Int)
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [()])
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
     , LeftDistributiveGCDMonoidInstance (mempty :: Dual [Word])
@@ -514,6 +524,9 @@ rightDistributiveGCDMonoidInstances =
     , RightDistributiveGCDMonoidInstance (mempty :: Identity [()])
     , RightDistributiveGCDMonoidInstance (mempty :: Identity [Bool])
     , RightDistributiveGCDMonoidInstance (mempty :: Identity [Word])
+    , RightDistributiveGCDMonoidInstance (mempty :: Const [()] Int)
+    , RightDistributiveGCDMonoidInstance (mempty :: Const [Bool] Int)
+    , RightDistributiveGCDMonoidInstance (mempty :: Const [Word] Int)
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [()])
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [Bool])
     , RightDistributiveGCDMonoidInstance (mempty :: Dual [Word])
@@ -523,6 +536,7 @@ lcmInstances =
     [LCMMonoidInstance (mempty :: Product Natural),
      LCMMonoidInstance (mempty :: Sum Natural),
      LCMMonoidInstance (mempty :: Identity (Sum Natural)),
+     LCMMonoidInstance (mempty :: Const (Sum Natural) Int),
      LCMMonoidInstance (mempty :: Dual (Product Natural)),
      LCMMonoidInstance (mempty :: Dual (Sum Natural)),
      LCMMonoidInstance (mempty :: IntSet),
@@ -545,6 +559,7 @@ distributiveLCMInstances =
     , DistributiveLCMMonoidInstance (mempty :: Set Bool)
     , DistributiveLCMMonoidInstance (mempty :: Set Word)
     , DistributiveLCMMonoidInstance (mempty :: Identity (Sum Natural))
+    , DistributiveLCMMonoidInstance (mempty :: Const (Sum Natural) Int)
     , DistributiveLCMMonoidInstance (mempty :: Dual (Product Natural))
     , DistributiveLCMMonoidInstance (mempty :: Dual (Sum Natural))
     ]

--- a/src/Data/Monoid/Factorial.hs
+++ b/src/Data/Monoid/Factorial.hs
@@ -18,6 +18,7 @@ module Data.Monoid.Factorial (
 where
 
 import Control.Arrow (first)
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid (..), Dual(..), Sum(..), Product(..), Endo(Endo, appEndo))
 import qualified Data.Foldable as Foldable
@@ -167,6 +168,8 @@ instance FactorialMonoid () where
    splitPrimeSuffix () = Nothing
 
 deriving instance FactorialMonoid a => FactorialMonoid (Identity a)
+
+deriving instance FactorialMonoid a => FactorialMonoid (Const a b)
 
 instance FactorialMonoid a => FactorialMonoid (Dual a) where
    splitPrimePrefix (Dual a) = case splitPrimeSuffix a

--- a/src/Data/Monoid/GCD.hs
+++ b/src/Data/Monoid/GCD.hs
@@ -65,6 +65,7 @@ module Data.Monoid.GCD
 
 import qualified Prelude
 
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
 import qualified Data.ByteString as ByteString
@@ -293,6 +294,12 @@ instance RightGCDMonoid () where
 deriving instance GCDMonoid a => GCDMonoid (Identity a)
 deriving instance LeftGCDMonoid a => LeftGCDMonoid (Identity a)
 deriving instance RightGCDMonoid a => RightGCDMonoid (Identity a)
+
+-- Const instances
+
+deriving instance GCDMonoid a => GCDMonoid (Const a b)
+deriving instance LeftGCDMonoid a => LeftGCDMonoid (Const a b)
+deriving instance RightGCDMonoid a => RightGCDMonoid (Const a b)
 
 -- Dual instances
 
@@ -627,6 +634,7 @@ class (LeftDistributiveGCDMonoid m, RightDistributiveGCDMonoid m, GCDMonoid m)
 
 instance DistributiveGCDMonoid ()
 instance DistributiveGCDMonoid a => DistributiveGCDMonoid (Identity a)
+instance DistributiveGCDMonoid a => DistributiveGCDMonoid (Const a b)
 instance DistributiveGCDMonoid (Product Natural)
 instance DistributiveGCDMonoid (Sum Natural)
 instance DistributiveGCDMonoid IntSet.IntSet
@@ -666,6 +674,7 @@ instance Ord a => LeftDistributiveGCDMonoid (Set.Set a)
 
 -- Instances for monoid transformers:
 instance LeftDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Identity a)
+instance LeftDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Const a b)
 instance RightDistributiveGCDMonoid a => LeftDistributiveGCDMonoid (Dual a)
 
 --------------------------------------------------------------------------------
@@ -701,4 +710,5 @@ instance Ord a => RightDistributiveGCDMonoid (Set.Set a)
 
 -- Instances for monoid transformers:
 instance RightDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Identity a)
+instance RightDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Const a b)
 instance LeftDistributiveGCDMonoid a => RightDistributiveGCDMonoid (Dual a)

--- a/src/Data/Monoid/LCM.hs
+++ b/src/Data/Monoid/LCM.hs
@@ -23,6 +23,7 @@ module Data.Monoid.LCM
 import Prelude hiding (gcd, lcm, max)
 import qualified Prelude
 
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
 import Data.IntSet (IntSet)
 import Data.Monoid (Dual (..), Product (..), Sum (..))
@@ -111,6 +112,8 @@ instance LCMMonoid () where
 
 deriving instance LCMMonoid a => LCMMonoid (Identity a)
 
+deriving instance LCMMonoid a => LCMMonoid (Const a b)
+
 instance LCMMonoid a => LCMMonoid (Dual a) where
     lcm (Dual a) (Dual b) = Dual (lcm a b)
 
@@ -172,6 +175,7 @@ class (DistributiveGCDMonoid m, LCMMonoid m) => DistributiveLCMMonoid m
 
 instance DistributiveLCMMonoid ()
 instance DistributiveLCMMonoid a => DistributiveLCMMonoid (Identity a)
+instance DistributiveLCMMonoid a => DistributiveLCMMonoid (Const a b)
 instance DistributiveLCMMonoid (Product Natural)
 instance DistributiveLCMMonoid (Sum Natural)
 instance DistributiveLCMMonoid IntSet

--- a/src/Data/Monoid/Monus.hs
+++ b/src/Data/Monoid/Monus.hs
@@ -17,6 +17,7 @@ module Data.Monoid.Monus (
    )
 where
 
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
 import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
 import qualified Data.ByteString as ByteString
@@ -140,6 +141,11 @@ instance OverlappingGCDMonoid () where
 
 deriving instance Monus a => Monus (Identity a)
 deriving instance OverlappingGCDMonoid a => OverlappingGCDMonoid (Identity a)
+
+-- Const instances
+
+deriving instance Monus a => Monus (Const a b)
+deriving instance OverlappingGCDMonoid a => OverlappingGCDMonoid (Const a b)
 
 -- Dual instances
 

--- a/src/Data/Monoid/Null.hs
+++ b/src/Data/Monoid/Null.hs
@@ -142,8 +142,7 @@ instance (MonoidNull (f a), MonoidNull (g a)) => MonoidNull (Functor.Product f g
 #endif
 
 -- | @since 1.2.5.0
-instance MonoidNull r => MonoidNull (Const r a) where
-   null (Const r) = null r
+deriving instance MonoidNull a => MonoidNull (Const a b)
 
 -- | @since 1.2.5.0
 deriving instance MonoidNull a => MonoidNull (Identity a)

--- a/src/Data/Semigroup/Cancellative.hs
+++ b/src/Data/Semigroup/Cancellative.hs
@@ -251,21 +251,16 @@ instance RightReductive All where
 -- Identity & Const instances
 
 deriving instance Reductive a => Reductive (Identity a)
-instance Reductive a => Reductive (Const a x) where
-   Const a </> Const b = Const <$> (a </> b)
+deriving instance Reductive a => Reductive (Const a b)
 
 instance Cancellative a => Cancellative (Identity a)
 instance Cancellative a => Cancellative (Const a x)
 
 deriving instance LeftReductive a => LeftReductive (Identity a)
-instance LeftReductive a => LeftReductive (Const a x) where
-   stripPrefix (Const a) (Const b) = Const <$> stripPrefix a b
-   isPrefixOf (Const a) (Const b) = isPrefixOf a b
+deriving instance LeftReductive a => LeftReductive (Const a b)
 
 deriving instance RightReductive a => RightReductive (Identity a)
-instance RightReductive a => RightReductive (Const a x) where
-   stripSuffix (Const a) (Const b) = Const <$> stripSuffix a b
-   isSuffixOf (Const a) (Const b) = isSuffixOf a b
+deriving instance RightReductive a => RightReductive (Const a b)
 
 instance LeftCancellative a => LeftCancellative (Identity a)
 instance LeftCancellative a => LeftCancellative (Const a x)

--- a/src/Data/Semigroup/Factorial.hs
+++ b/src/Data/Semigroup/Factorial.hs
@@ -425,6 +425,7 @@ instance Factorial (Vector.Vector a) where
    reverse = Vector.reverse
 
 instance StableFactorial ()
+instance StableFactorial a => StableFactorial (Identity a)
 instance StableFactorial a => StableFactorial (Dual a)
 instance StableFactorial [x]
 instance StableFactorial ByteString.ByteString

--- a/src/Data/Semigroup/Factorial.hs
+++ b/src/Data/Semigroup/Factorial.hs
@@ -20,6 +20,7 @@ module Data.Semigroup.Factorial (
 where
 
 import qualified Control.Monad as Monad
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity (Identity (Identity))
 import Data.Semigroup -- (Semigroup (..), Dual(..), Sum(..), Product(..), Endo(Endo, appEndo))
 import qualified Data.Foldable as Foldable
@@ -121,6 +122,8 @@ instance Factorial () where
    reverse = id
 
 deriving instance Factorial a => Factorial (Identity a)
+
+deriving instance Factorial a => Factorial (Const a b)
 
 instance Factorial a => Factorial (Dual a) where
    factors (Dual a) = fmap Dual (reverse $ factors a)
@@ -426,6 +429,7 @@ instance Factorial (Vector.Vector a) where
 
 instance StableFactorial ()
 instance StableFactorial a => StableFactorial (Identity a)
+instance StableFactorial a => StableFactorial (Const a b)
 instance StableFactorial a => StableFactorial (Dual a)
 instance StableFactorial [x]
 instance StableFactorial ByteString.ByteString


### PR DESCRIPTION
This PR defines more class instances for the [`Const`](https://hackage.haskell.org/package/base-4.21.0.0/docs/Data-Functor-Const.html#t:Const) type.

The approach used is similar to `base`, which uses [`GeneralizedNewtypeDeriving`](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/newtype_deriving.html) to auto-derive instances of `Semigroup` and `Monoid` for `Const`:

```hs
newtype Const a b = Const { getConst :: a }
    deriving ( ...
             , Semigroup  -- ^ @since base-4.9.0.0
             , Monoid     -- ^ @since base-4.9.0.0
             , ...
             )
```
(See source [here](https://hackage.haskell.org/package/ghc-internal-9.1201.0/docs/src/GHC.Internal.Data.Functor.Const.html#Const).)

In addition, this PR:
- uses `GeneralizedNewtypeDeriving` to simplify the remaining existing class instances for `Const`.
- adds test coverage for `Const` class instances.

And finally:
- adds one missing `Identity` instance for `StableFactorial`.
  (This was missing from https://github.com/blamario/monoid-subclasses/pull/54)