### PR TITLE
Test support for newer GHC versions.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,14 +28,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.8.2
+          - compiler: ghc-9.12.1
             compilerKind: ghc
-            compilerVersion: 9.8.2
+            compilerVersion: 9.12.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.4
+          - compiler: ghc-9.10.1
             compilerKind: ghc
-            compilerVersion: 9.6.4
+            compilerVersion: 9.10.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.8.4
+            compilerKind: ghc
+            compilerVersion: 9.8.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.6
+            compilerKind: ghc
+            compilerVersion: 9.6.6
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8

--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -15,6 +15,8 @@ Tested-with:         GHC==8.0.2
                    , GHC==9.4.8
                    , GHC==9.6.6
                    , GHC==9.8.4
+                   , GHC==9.10.1
+                   , GHC==9.12.1
 
 Description:
   A hierarchy of subclasses of 'Monoid' together with their instances for all data structures from base, containers, and

--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -13,8 +13,8 @@ Tested-with:         GHC==8.0.2
                    , GHC==9.0.2
                    , GHC==9.2.8
                    , GHC==9.4.8
-                   , GHC==9.6.4
-                   , GHC==9.8.2
+                   , GHC==9.6.6
+                   , GHC==9.8.4
 
 Description:
   A hierarchy of subclasses of 'Monoid' together with their instances for all data structures from base, containers, and

--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -4,8 +4,18 @@ Cabal-Version:       >= 1.10
 Build-Type:          Simple
 Synopsis:            Subclasses of Monoid
 Category:            Data, Algebra, Text
-Tested-with:         GHC==9.8.2, GHC==9.6.4, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2,
-                     GHC==8.10.7, GHC==8.8.4, GHC==8.6.5, GHC==8.4.4, GHC==8.2.2, GHC==8.0.2
+Tested-with:         GHC==8.0.2
+                   , GHC==8.2.2
+                   , GHC==8.4.4
+                   , GHC==8.6.5
+                   , GHC==8.8.4
+                   , GHC==8.10.7
+                   , GHC==9.0.2
+                   , GHC==9.2.8
+                   , GHC==9.4.8
+                   , GHC==9.6.4
+                   , GHC==9.8.2
+
 Description:
   A hierarchy of subclasses of 'Monoid' together with their instances for all data structures from base, containers, and
   text packages.

--- a/monoid-subclasses.cabal
+++ b/monoid-subclasses.cabal
@@ -9,7 +9,7 @@ Tested-with:         GHC==9.8.2, GHC==9.6.4, GHC==9.4.8, GHC==9.2.8, GHC==9.0.2,
 Description:
   A hierarchy of subclasses of 'Monoid' together with their instances for all data structures from base, containers, and
   text packages.
-  
+
 License:             BSD3
 License-file:        BSD3-LICENSE.txt
 Copyright:           (c) 2013-2024 Mario Blažević


### PR DESCRIPTION
This PR updates the `tested-with` declaration (in `monoid-subclasses.cabal`) to include the following GHC versions:
- `9.6.6`
- `9.8.4`
- `9.10.12`
- `9.12.1`

In addition, this PR regenerates `haskell-ci.yml` so that CI will compile and test with these versions of GHC.